### PR TITLE
Add rewrite rule to map helm charts

### DIFF
--- a/themes/solr/templates/htaccess.template
+++ b/themes/solr/templates/htaccess.template
@@ -80,3 +80,4 @@ RewriteRule ^guide/\d+_\d+/(?!.+\.\w+$|.+/$).+$             $0/ [R=301,L]
 RewriteRule ^docs/(\d+_\d+_\d+/.*)$  __root/docs.lucene.apache.org/content/solr/$1 [PT]
 RewriteRule ^guide/\d+_\d+/.*$       __root/docs.lucene.apache.org/content/solr/$0 [PT]
 
+RewriteRule ^charts/(.*)$ https://nightlies.apache.org/solr/helm-charts/$1 [PT]


### PR DESCRIPTION
Right now we have to store the artifacts in nightlies.apache.org, but they will have a more permanent location soon.

https://issues.apache.org/jira/browse/INFRA-21504

I have the helm chart repo setup there currently, just for testing but it should work. https://nightlies.apache.org/solr/helm-charts/

I didn't put this under `/solr/operator`, because in the future we will likely have helm charts for Solr Cloud, Solr Prometheus Exporter, and whatever add-ons we have.