### PR TITLE
Better mailing list description, buttons for (un)subscribe

### DIFF
--- a/content/pages/community.md
+++ b/content/pages/community.md
@@ -15,7 +15,7 @@ here. There are also a number of external companies and professionals ready to h
 
 We use [mailing lists](https://apache.org/foundation/mailinglists.html) for all official project communications.
 To subscribe or unsubscribe you need to send an email to special addresses (listed below) from *the email address you
-want to subscribe as*, and then confirm your ownership of that address by replying to a mail from the list software.
+want to subscribe as or unsubscribe from*, and then confirm your ownership of that address by replying to a mail from the list software.
 
 #### Mailing list etiquette
 

--- a/content/pages/community.md
+++ b/content/pages/community.md
@@ -48,17 +48,17 @@ Also see developer discussion archives at [dev@lucene.apache.org](https://lists.
 
 #### Notification / automated announcements lists for developers ####
 
-Notifications about all JIRA issues and Github pull requests:
+Notifications about JIRA issues / Pull Requests - **issues@solr.apache.org**:
 <a class="btn" href="mailto:issues-subscribe@solr.apache.org">Subscribe</a>
 <a class="btn" href="mailto:issues-unsubscribe@solr.apache.org">Unsubscribe</a>
 <a class="btn" href="https://lists.apache.org/list.html?issues@solr.apache.org">Archives</a>
 
-Notifications about all CI builds by Jenkins:
+Notifications about all CI builds by Jenkins - **builds@solr.apache.org**:
 <a class="btn" href="mailto:builds-subscribe@solr.apache.org">Subscribe</a>
 <a class="btn" href="mailto:builds-unsubscribe@solr.apache.org">Unsubscribe</a>
 <a class="btn" href="https://lists.apache.org/list.html?builds@solr.apache.org">Archives</a>
 
-Notifications about every Solr commit:
+Notifications about every Solr commit - **commits@solr.apache.org**:
 <a class="btn" href="mailto:commits-subscribe@solr.apache.org">Subscribe</a>
 <a class="btn" href="mailto:commits-unsubscribe@solr.apache.org">Unsubscribe</a>
 <a class="btn" href="https://lists.apache.org/list.html?commits@solr.apache.org">Archives</a>

--- a/content/pages/community.md
+++ b/content/pages/community.md
@@ -13,6 +13,10 @@ here. There are also a number of external companies and professionals ready to h
 
 ## Mailing Lists & Chat ##
 
+We use [mailing lists](https://apache.org/foundation/mailinglists.html) for all official project communications.
+To subscribe or unsubscribe you need to send an email to special addresses (listed below) from *the email address you
+want to subscribe as*, and then confirm your ownership of that address by replying to a mail from the list software.
+
 #### Mailing list etiquette
 
 Written communication is hard and prone to misunderstandings. We recommend reading [ComDev's etiquette page](https://community.apache.org/contributors/etiquette) for some practical tips on how to improve.
@@ -23,7 +27,10 @@ This list is for users of Solr to ask questions, share knowledge, and discuss is
 users to send usage and configuration questions and problems to this mailing list.  Before filing an issue in
 the JIRA issue tracker, make sure it's a real bug and that it hasn't been already discovered by discussing it here.
 
-[Subscribe - Unsubscribe - Archives : users@solr.apache.org at Apache's PonyMail](https://lists.apache.org/list.html?users@solr.apache.org).
+<a class="btn" href="mailto:users-subscribe@solr.apache.org">Subscribe</a>
+<a class="btn" href="mailto:users-unsubscribe@solr.apache.org">Unsubscribe</a>
+<a class="btn" href="https://lists.apache.org/list.html?users@solr.apache.org">Archives</a>
+<a class="btn" href="mailto:users@solr.apache.org?subject=Question about Solr">Send mail to list</a>
 
 > **NOTE:** This list was named [solr-user@lucene.apache.org](https://lists.apache.org/list.html?solr-user@lucene.apache.org) while Solr was a Lucene subproject. The list was migrated to Solr in March 2021, including subscriptions and archive.
 
@@ -32,20 +39,29 @@ the JIRA issue tracker, make sure it's a real bug and that it hasn't been alread
 This is the list where participating developers of the Solr project meet and discuss
 issues concerning Solr internals, code changes/additions, etc. **Please do not send mail to this list with usage questions or configuration questions and problems, that is what the users mailing list is for.**
 
-[Subscribe - Unsubscribe - Archives : dev@solr.apache.org at Apache's PonyMail](https://lists.apache.org/list.html?dev@solr.apache.org).
+<a class="btn" href="mailto:dev-subscribe@solr.apache.org">Subscribe</a>
+<a class="btn" href="mailto:dev-unsubscribe@solr.apache.org">Unsubscribe</a>
+<a class="btn" href="https://lists.apache.org/list.html?dev@solr.apache.org">Archives</a>
+<a class="btn" href="mailto:dev@solr.apache.org?subject=Question about Solr">Send mail to list</a>
 
 Also see developer discussion archives at [dev@lucene.apache.org](https://lists.apache.org/list.html?dev@lucene.apache.org) from when Solr was a Lucene subproject.
 
 #### Notification / automated announcements lists for developers ####
 
-Notifications about all JIRA issues and Github pull requests:  
-[Subscribe - Unsubscribe - Archives : issues@solr.apache.org at Apache's PonyMail](https://lists.apache.org/list.html?issues@solr.apache.org).
+Notifications about all JIRA issues and Github pull requests:
+<a class="btn" href="mailto:issues-subscribe@solr.apache.org">Subscribe</a>
+<a class="btn" href="mailto:issues-unsubscribe@solr.apache.org">Unsubscribe</a>
+<a class="btn" href="https://lists.apache.org/list.html?issues@solr.apache.org">Archives</a>
 
-Notifications about all CI builds by Jenkins:  
-[Subscribe - Unsubscribe - Archives : builds@solr.apache.org at Apache's PonyMail](https://lists.apache.org/list.html?builds@solr.apache.org).
+Notifications about all CI builds by Jenkins:
+<a class="btn" href="mailto:builds-subscribe@solr.apache.org">Subscribe</a>
+<a class="btn" href="mailto:builds-unsubscribe@solr.apache.org">Unsubscribe</a>
+<a class="btn" href="https://lists.apache.org/list.html?builds@solr.apache.org">Archives</a>
 
-Notifications about every Solr commit:  
-[Subscribe - Unsubscribe - Archives : commits@solr.apache.org at Apache's PonyMail](https://lists.apache.org/list.html?commits@solr.apache.org).
+Notifications about every Solr commit:
+<a class="btn" href="mailto:commits-subscribe@solr.apache.org">Subscribe</a>
+<a class="btn" href="mailto:commits-unsubscribe@solr.apache.org">Unsubscribe</a>
+<a class="btn" href="https://lists.apache.org/list.html?commits@solr.apache.org">Archives</a>
 
 #### IRC  ####
 


### PR DESCRIPTION
There has been complaints about it being too hard to subscribe/unsubscribe from lists with the new web page's singular link to lists.apache.org location of the list. While that page has buttons for subscribe and unsubscribe, it appears that people get confused, and it also turns out those buttons are not visisble from mobile devices.

This PR adds buttons for each action, see screenshot

![Skjermbilde 2021-03-09 kl  13 04 20](https://user-images.githubusercontent.com/409128/110468049-0c256280-80d8-11eb-91c0-d4ad50a9bd78.png)

It also adds a description about what a mailing list is and how to subscribe.