### PR TITLE
SOLR-14497 Use https://solr.apache.org/doap/solr.rdf as DOAP location

### DIFF
--- a/themes/solr/templates/htaccess.template
+++ b/themes/solr/templates/htaccess.template
@@ -26,7 +26,7 @@ RewriteBase /
 ### Pre-CMS site redirects
 
 # DOAP file redirects to source repository
-RedirectMatch Permanent ^/doap.rdf https://gitbox.apache.org/repos/asf?p=solr.git;a=blob_plain;f=dev-tools/doap/solr.rdf;hb=HEAD
+RedirectMatch Permanent ^/doap/solr.rdf https://gitbox.apache.org/repos/asf?p=lucene-solr.git;a=blob_plain;f=dev-tools/doap/solr.rdf;hb=HEAD
 
 # Solr site redesign
 # needs to use mod_rewrite because of the anchor fragments


### PR DESCRIPTION
This means we can change the location in  https://svn.apache.org/repos/asf/comdev/projects.apache.org/trunk/data/projects.xml  to point to solr website for the DOAP, and once we move source repos, we just change the .htaccess