### PR TITLE
Update ASF event banner to recommended style

### DIFF
--- a/themes/solr/templates/_javascript.html
+++ b/themes/solr/templates/_javascript.html
@@ -6,3 +6,4 @@
 <script src="//cdn.jsdelivr.net/jquery.slick/1.3.7/slick.min.js"/></script>
 <script src="{{ SITEURL }}/theme/javascript/lib/jquery.smooth-scroll.min.js{{ STATIC_RESOURCE_SUFFIX }}"></script>
 <script src="{{ SITEURL }}/theme/javascript/main.js{{ STATIC_RESOURCE_SUFFIX }}"></script>
+<script src="https://www.apachecon.com/event-images/snippet.js"></script>

--- a/themes/solr/templates/index.html
+++ b/themes/solr/templates/index.html
@@ -327,10 +327,9 @@
       <p>
       The Apache Software Foundation provides support for the Apache community of open-source software projects. The Apache projects are defined by collaborative consensus based processes, an open, pragmatic software license and a desire to create high quality software that leads the way in its field. Apache Lucene, Apache Solr, Apache PyLucene, Apache Open Relevance Project and their respective logos are trademarks of The Apache Software Foundation. All other marks mentioned may be trademarks or registered trademarks of their respective owners.
       </p>
+      <hr/>
       <p>
-      <a target="_blank" href="https://www.apache.org/events/current-event.html">
-        <img src="https://www.apache.org/events/current-event-234x60.png"/>
-      </a>
+        <a class="acevent" data-format="wide" data-mode="light" data-width="480"></a>
       </p>
     </div>
   </div>


### PR DESCRIPTION
Received an email to members@ about a new way to include ApacehCon banner on the websites. See https://www.apachecon.com/event-images/

This PR updates this for Solr, see screenshot below. I have made the banner a bit larger and light color instead of black since it is on a white backround.
Before:
![Skjermbilde 2021-03-19 kl  17 08 20](https://user-images.githubusercontent.com/409128/111809893-be79d880-88d5-11eb-8fa8-0a5ef64f7c45.png)
After:
![Skjermbilde 2021-03-19 kl  17 06 14](https://user-images.githubusercontent.com/409128/111809769-a1450a00-88d5-11eb-90eb-d6cc206d8fe7.png)
