### PR TITLE
Remove books from frontpage, they are old

### DIFF
--- a/themes/solr/templates/index.html
+++ b/themes/solr/templates/index.html
@@ -294,30 +294,6 @@
   </div>
 </section>
 
-<section class="gray">
-  <div class="row">
-    <div class="large-12 columns">
-      <div class="annotation">
-        Deep expertise
-      </div>
-      <h1>
-        Solr Books<br/>
-        <small>The definitive in-depth resource library written by the world's Solr experts.</small>
-      </h1>
-      <hr/>
-      <ul class="books small-block-grid-2 medium-block-grid-3 large-block-grid-6">
-        <li><a href="/resources.html#book-asess-3ed"><img src="{{ SITEURL }}/theme/images/book_asess_3ed.jpg"/></a></li>
-        <li><a href="/resources.html#book-scaling-big-data-hadoop-solr-II"><img src="{{ SITEURL }}/theme/images/book_scaling_big_data_hadoop_solr_II.jpg"/></a></li>
-        <li><a href="/resources.html#book-solr-search-patterns"><img src="{{ SITEURL }}/theme/images/book_solr_search_patterns.jpg"/></a></li>
-        <li><a href="/resources.html#book-solr-cookbook-3ed"><img src="{{ SITEURL }}/theme/images/book_solr_cookbook_3ed.jpg"/></a></li>
-        <li><a href="/resources.html#mastering-apache-solr"><img src="{{ SITEURL }}/theme/images/book_mas.jpg"/></a></li>
-        <li><a href="/resources.html#solr-in-action"><img src="{{ SITEURL }}/theme/images/book_sia.png"/></a></li>
-      </ul>
-      <a class="btn" href="/resources.html#solr-books">Learn More</a>
-    </div>
-  </div>
-</section>
-
 <section class="white">
   <div class="row">
     <div class="large-12 columns text-center">


### PR DESCRIPTION
We highlight several books on the frontpage of Solr site.
However, the newest book is from 2015 - 6 years old, so why would we promote those on the front page? I think it was mentioned in an email thread somewhere too. Here's a PR to remove that section from front page, while keeping them on the resources page.

Instead, we could add sections to the front page about Solr-Operator and/or other relevant things.