### PR TITLE
Add artifactHub widget to resources and downloads.

### DIFF
--- a/content/pages/operator/resources.md
+++ b/content/pages/operator/resources.md
@@ -16,6 +16,24 @@ Users who have completed the tutorial are encouraged to review the [other docume
 
 ***
 
+## Helm Charts ##
+
+If you want to run Solr on Kubernetes, the easiest way to get started is via installing the Helm charts below.
+
+* **Solr Operator** - A management layer that runs independently in Kubernetes. Only deploy 1 per Kubernetes cluster or namespace.
+<!-- Uncomment when v0.4.0 is released
+* **Solr** - A SolrCloud cluster. In order to deploy this Helm chart successfully, you must first install the Solr Operator and Solr CRDs. Follow the instructions on the ArtifactHub page below.
+-->
+
+<div style="display:flex; justify-content: space-evenly">
+  <div class="artifacthub-widget" data-url="https://artifacthub.io/packages/helm/apache-solr/solr-operator" data-theme="light" data-header="false" data-responsive="true"></div><script async src="https://artifacthub.io/artifacthub-widget.js"></script>
+  <!-- Uncomment when v0.4.0 is released
+  <div class="artifacthub-widget" data-url="https://artifacthub.io/packages/helm/apache-solr/solr" data-theme="light" data-header="false" data-responsive="true"></div><script async src="https://artifacthub.io/artifacthub-widget.js"></script>
+  -->
+</div>
+
+***
+
 ## Documentation ##
 
 <h3 class="offset" id="the-apache-solr-reference-guide">The Apache Solr Reference Guide</h3>

--- a/content/pages/resources.md
+++ b/content/pages/resources.md
@@ -45,6 +45,24 @@ Additional documentation can be found on the [Solr Community Wiki](https://cwiki
 
 ***
 
+## Helm Charts ##
+
+If you want to run Solr on Kubernetes, the easiest way to get started is via installing the Helm charts below.
+
+* **[Solr Operator](/operator)** - A management layer that runs independently in Kubernetes. Only deploy 1 per Kubernetes cluster or namespace.
+<!-- Uncomment when v0.4.0 is released
+* **Solr** - A SolrCloud cluster. In order to deploy this Helm chart successfully, you must first install the Solr Operator and Solr CRDs. Follow the instructions on the ArtifactHub page below.
+-->
+
+<div style="display:flex; justify-content: space-evenly">
+  <div class="artifacthub-widget" data-url="https://artifacthub.io/packages/helm/apache-solr/solr-operator" data-theme="light" data-header="false" data-responsive="true"></div><script async src="https://artifacthub.io/artifacthub-widget.js"></script>
+  <!-- Uncomment when v0.4.0 is released
+  <div class="artifacthub-widget" data-url="https://artifacthub.io/packages/helm/apache-solr/solr" data-theme="light" data-header="false" data-responsive="true"></div><script async src="https://artifacthub.io/artifacthub-widget.js"></script>
+  -->
+</div>
+
+***
+
 ## Solr Books ##
 
 If you have a Solr book that you would like to see listed here, please [edit this website and submit a Pull Request](/editing-website.html).

--- a/themes/solr/static/css/base.css
+++ b/themes/solr/static/css/base.css
@@ -415,6 +415,10 @@ section {
   text-align:center;
 }
 
+.artifacthub-widget > section {
+  padding: 0;
+}
+
 section.gray {
   background-color: #f9f8f8;
 }

--- a/themes/solr/static/css/operator.css
+++ b/themes/solr/static/css/operator.css
@@ -415,6 +415,10 @@ section {
   text-align:center;
 }
 
+.artifacthub-widget > section {
+  padding: 0;
+}
+
 section.gray {
   background-color: #f9f8f8;
 }

--- a/themes/solr/templates/operator/downloads.html
+++ b/themes/solr/templates/operator/downloads.html
@@ -21,35 +21,40 @@
 
   <p>Solr Operator {{ SOLR_OPERATOR_LATEST_RELEASE }} is the most recent Apache Solr Operator release.</p>
 
-  <ul>
-    <li>Source release:
-      <a href="https://www.apache.org/dyn/closer.lua/solr/solr-operator/{{ SOLR_OPERATOR_LATEST_RELEASE }}/solr-operator-{{ SOLR_OPERATOR_LATEST_RELEASE }}.tgz">solr-operator-{{ SOLR_OPERATOR_LATEST_RELEASE }}.tgz</a>
-      [<a href="https://downloads.apache.org/solr/solr-operator/{{ SOLR_OPERATOR_LATEST_RELEASE }}/solr-operator-{{ SOLR_OPERATOR_LATEST_RELEASE }}.tgz.asc">PGP</a>]
-      [<a href="https://downloads.apache.org/solr/solr-operator/{{ SOLR_OPERATOR_LATEST_RELEASE }}/solr-operator-{{ SOLR_OPERATOR_LATEST_RELEASE }}.tgz.sha512">SHA512</a>]
-    </li>
+  <div style="display:flex">
+    <ul style="margin: 0.75rem; flex-shrink: 0">
+      <li>Source release:
+        <a href="https://www.apache.org/dyn/closer.lua/solr/solr-operator/{{ SOLR_OPERATOR_LATEST_RELEASE }}/solr-operator-{{ SOLR_OPERATOR_LATEST_RELEASE }}.tgz">solr-operator-{{ SOLR_OPERATOR_LATEST_RELEASE }}.tgz</a>
+        [<a href="https://downloads.apache.org/solr/solr-operator/{{ SOLR_OPERATOR_LATEST_RELEASE }}/solr-operator-{{ SOLR_OPERATOR_LATEST_RELEASE }}.tgz.asc">PGP</a>]
+        [<a href="https://downloads.apache.org/solr/solr-operator/{{ SOLR_OPERATOR_LATEST_RELEASE }}/solr-operator-{{ SOLR_OPERATOR_LATEST_RELEASE }}.tgz.sha512">SHA512</a>]
+      </li>
 
-    <li>Docker releases:
-      <a href="https://hub.docker.com/r/apache/solr-operator">apache/solr-operator</a>
-    </li>
+      <li>Docker releases:
+        <a href="https://hub.docker.com/r/apache/solr-operator">apache/solr-operator</a>
+      </li>
 
-    <li>Helm Chart release:
-      <a href="https://artifacthub.io/packages/helm/apache-solr/solr-operator/{{ SOLR_OPERATOR_LATEST_RELEASE  | replace("v", "") }}">Artifact Hub</a><br/>
-      <i>Use <code>{{ SOLR_OPERATOR_LATEST_RELEASE  | replace("v", "") }}</code> as the version of the Helm Chart.</i>
-    </li>
+      <li>Helm Chart release:
+        <a href="https://artifacthub.io/packages/helm/apache-solr/solr-operator/{{ SOLR_OPERATOR_LATEST_RELEASE  | replace("v", "") }}">Artifact Hub</a><br/>
+        <i>Use <code>{{ SOLR_OPERATOR_LATEST_RELEASE  | replace("v", "") }}</code> as the version of the Helm Chart.</i>
+      </li>
 
-    <li>CRDs:
-      <ul>
-        <li><a href="{{ SITEURL }}/operator/downloads/crds/{{ SOLR_OPERATOR_LATEST_RELEASE }}/all.yaml">All</a></li>
-        <li><a href="{{ SITEURL }}/operator/downloads/crds/{{ SOLR_OPERATOR_LATEST_RELEASE }}/all-with-dependencies.yaml">All with Dependencies (Zookeeper)</a></li>
-        <li><a href="{{ SITEURL }}/operator/downloads/crds/{{ SOLR_OPERATOR_LATEST_RELEASE }}/solrclouds.yaml">Solr Cloud</a></li>
-        <li><a href="{{ SITEURL }}/operator/downloads/crds/{{ SOLR_OPERATOR_LATEST_RELEASE }}/solrprometheusexporters.yaml">Solr Prometheus Exporter</a></li>
-        <li><a href="{{ SITEURL }}/operator/downloads/crds/{{ SOLR_OPERATOR_LATEST_RELEASE }}/solrbackups.yaml">Solr Backup</a></li>
-      </ul>
-    </li>
+      <li>CRDs:
+        <ul>
+          <li><a href="{{ SITEURL }}/operator/downloads/crds/{{ SOLR_OPERATOR_LATEST_RELEASE }}/all.yaml">All</a></li>
+          <li><a href="{{ SITEURL }}/operator/downloads/crds/{{ SOLR_OPERATOR_LATEST_RELEASE }}/all-with-dependencies.yaml">All with Dependencies (Zookeeper)</a></li>
+          <li><a href="{{ SITEURL }}/operator/downloads/crds/{{ SOLR_OPERATOR_LATEST_RELEASE }}/solrclouds.yaml">Solr Cloud</a></li>
+          <li><a href="{{ SITEURL }}/operator/downloads/crds/{{ SOLR_OPERATOR_LATEST_RELEASE }}/solrprometheusexporters.yaml">Solr Prometheus Exporter</a></li>
+          <li><a href="{{ SITEURL }}/operator/downloads/crds/{{ SOLR_OPERATOR_LATEST_RELEASE }}/solrbackups.yaml">Solr Backup</a></li>
+        </ul>
+      </li>
 
-    <!-- TODO: Put change log in site -->
-    <li><a href="https://github.com/apache/solr-operator/releases/{{ SOLR_OPERATOR_LATEST_RELEASE }}">Change log</a></li>
-  </ul>
+      <!-- TODO: Put change log in site -->
+      <li><a href="https://artifacthub.io/packages/helm/apache-solr/solr-operator/{{ SOLR_OPERATOR_LATEST_RELEASE  | replace("v", "") }}?modal=changelog">Change log</a></li>
+    </ul>
+
+    <div class="artifacthub-widget" data-url="https://artifacthub.io/packages/helm/apache-solr/solr-operator" data-theme="light" data-header="true" data-responsive="true"></div>
+    <script async src="https://artifacthub.io/artifacthub-widget.js"></script>
+  </div>
 
   <h3 id="solr-{{ SOLR_OPERATOR_PREVIOUS_MAJOR_RELEASE | replace(".", "") }}">Solr Operator {{ SOLR_OPERATOR_PREVIOUS_MAJOR_RELEASE }}
     <a class="headerlink" href="#solr-{{ SOLR_OPERATOR_PREVIOUS_MAJOR_RELEASE | replace(".", "") }}" title="Permanent link">¶</a>

--- a/themes/solr/templates/operator/resources.html
+++ b/themes/solr/templates/operator/resources.html
@@ -4,6 +4,7 @@
 {% block subnav_subtitle %}Find everything you need about the Solr Operator<sup>&trade;</sup> here.{% endblock %}
 {% block subnav_nav_items %}
 <dd><a data-scroll href="#tutorials">Tutorials</a></dd>
+<dd><a data-scroll href="#helm-charts">Helm Charts</a></dd>
 <dd><a data-scroll href="#documentation">Docs</a></dd>
 <dd><a data-scroll href="#presentations">Presentations</a></dd>
 <dd><a data-scroll href="#videos">Videos</a></dd>

--- a/themes/solr/templates/resources.html
+++ b/themes/solr/templates/resources.html
@@ -5,6 +5,7 @@
 {% block subnav_nav_items %}
 <dd><a data-scroll href="#tutorials">Tutorials</a></dd>
 <dd><a data-scroll href="#documentation">Docs</a></dd>
+<dd><a data-scroll href="#helm-charts">Helm Charts</a></dd>
 <dd><a data-scroll href="#solr-books">Books</a></dd>
 <dd><a data-scroll href="#presentations">Presentations</a></dd>
 <dd><a data-scroll href="#videos">Videos</a></dd>


### PR DESCRIPTION
This is a new-ish feature of Artifact Hub. Thought it'd be a nice addition to help direct people to the page(s), since they are ripe with information.

The Solr helm chart is unreleased, so we have to comment that out until v0.4.0 of the Solr Operator is released.