### PR TITLE
Log4j: Solr's docker images are mitigated.

### DIFF
--- a/content/solr/security/2021-12-10-cve-2021-44228.md
+++ b/content/solr/security/2021-12-10-cve-2021-44228.md
@@ -19,6 +19,7 @@ The Prometheus Exporter Contrib is similarly separately affected.
 Any of the following are enough to prevent this vulnerability for Solr servers:
 
 * Upgrade to `Solr 8.11.1` or greater (when available), which will include an updated version of the log4j2 dependency.
+* If you are using Solr's official docker image, no matter the version, it has already been mitigated.  You may need to re-pull the image.
 * Manually update the version of log4j2 on your runtime classpath and restart your Solr application.
 * (Linux/MacOS) Edit your `solr.in.sh` file to include:
   `SOLR_OPTS="$SOLR_OPTS -Dlog4j2.formatMsgNoLookups=true"`
@@ -29,6 +30,7 @@ Any of the following are enough to prevent this vulnerability for Solr servers:
 The vulnerability in the Prometheus Exporter Contrib can be mitigated by any of the following:
 
 * Upgrade to `Solr 8.11.1` or greater (when available), which will include an updated version of the log4j2 dependency.
+* If you are using Solr's official docker image, no matter the version, it has already been mitigated.  You may need to re-pull the image.
 * Manually update the version of log4j2 on your runtime classpath and restart your Solr application.
 * Edit your `solr-exporter` script to include:
   `JAVA_OPTS="$JAVA_OPTS -Dlog4j2.formatMsgNoLookups=true"`


### PR DESCRIPTION
I also wonder if we should help users recognize that the system property was set correctly.  It's of course visible on the admin screen.