### PR TITLE
Log4J: Prometheus Exporter isn't vulnerable

### DIFF
--- a/content/solr/security/2021-12-10-cve-2021-44228.md
+++ b/content/solr/security/2021-12-10-cve-2021-44228.md
@@ -11,29 +11,20 @@ Critical
 **Description:**
 Apache Solr releases prior to 8.11.1 were using a bundled version of the Apache Log4J library vulnerable to RCE. For full impact and additional detail consult the Log4J security page.
 
-Apache Solr releases prior to 7.4 (i.e. Solr 5, Solr 6, and Solr 7 through 7.3) use log4j 1.2.17 which may be vulnerable for installations using non-default logging configurations that include the JMS Appender, see <https://github.com/apache/logging-log4j2/pull/608#issuecomment-990494126> for discussion.
+Apache Solr releases prior to 7.4 (i.e. Solr 5, Solr 6, and Solr 7 through 7.3) use Log4J 1.2.17 which may be vulnerable for installations using non-default logging configurations that include the JMS Appender, see <https://github.com/apache/logging-log4j2/pull/608#issuecomment-990494126> for discussion.
 
-The Prometheus Exporter Contrib is similarly separately affected.
+Solr's Prometheus Exporter uses Log4J as well but it does not log user input or data, so we don't see a risk there.
 
 **Mitigation:**
 Any of the following are enough to prevent this vulnerability for Solr servers:
 
-* Upgrade to `Solr 8.11.1` or greater (when available), which will include an updated version of the log4j2 dependency.
+* Upgrade to `Solr 8.11.1` or greater (when available), which will include an updated version of the Log4J dependency.
 * If you are using Solr's official docker image, no matter the version, it has already been mitigated.  You may need to re-pull the image.
-* Manually update the version of log4j2 on your runtime classpath and restart your Solr application.
+* Manually update the version of Log4J on your runtime classpath and restart your Solr application.
 * (Linux/MacOS) Edit your `solr.in.sh` file to include:
   `SOLR_OPTS="$SOLR_OPTS -Dlog4j2.formatMsgNoLookups=true"`
 * (Windows) Edit your `solr.in.cmd` file to include:
   `set SOLR_OPTS=%SOLR_OPTS% -Dlog4j2.formatMsgNoLookups=true`
-* Follow any of the other mitgations listed at <https://logging.apache.org/log4j/2.x/security.html>
-
-The vulnerability in the Prometheus Exporter Contrib can be mitigated by any of the following:
-
-* Upgrade to `Solr 8.11.1` or greater (when available), which will include an updated version of the log4j2 dependency.
-* If you are using Solr's official docker image, no matter the version, it has already been mitigated.  You may need to re-pull the image.
-* Manually update the version of log4j2 on your runtime classpath and restart your Solr application.
-* Edit your `solr-exporter` script to include:
-  `JAVA_OPTS="$JAVA_OPTS -Dlog4j2.formatMsgNoLookups=true"`
 * Follow any of the other mitgations listed at <https://logging.apache.org/log4j/2.x/security.html>
 
 **References:**


### PR DESCRIPTION
List conversation: https://lists.apache.org/thread/x1qkgyqxtb6mko1qr2qhq40j96q07sy7
Also made references to Log4J consistent in capitalization.