### PR TITLE
Clarify what docker versions are patched

### DIFF
--- a/content/solr/security/2021-12-10-cve-2021-44228.md
+++ b/content/solr/security/2021-12-10-cve-2021-44228.md
@@ -19,7 +19,7 @@ Solr's Prometheus Exporter uses Log4J as well but it does not log user input or 
 Any of the following are enough to prevent this vulnerability for Solr servers:
 
 * Upgrade to `Solr 8.11.1` or greater (when available), which will include an updated version of the Log4J dependency.
-* If you are using Solr's official docker image, no matter the version, it has already been mitigated.  You may need to re-pull the image.
+* If you are using Solr's official docker image, it has already been mitigated in all versions listed as supported on Docker Hub: <https://hub.docker.com/_/solr>.  You may need to re-pull the image.
 * Manually update the version of Log4J on your runtime classpath and restart your Solr application.
 * (Linux/MacOS) Edit your `solr.in.sh` file to include:
   `SOLR_OPTS="$SOLR_OPTS -Dlog4j2.formatMsgNoLookups=true"`


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/SOLR-15850

Not all docker versions / tags are updated with the sysprop, so we should specify that the tags listed as "supported" on hub are the ones that are safe. By policy that is all 8.x verions, latest 7.7 version, latest 6.x version, latest 5.x version.