### PR TITLE
Add a note about CVE-2021-45046

### DIFF
--- a/content/solr/security/2021-12-10-cve-2021-44228.md
+++ b/content/solr/security/2021-12-10-cve-2021-44228.md
@@ -15,10 +15,14 @@ Apache Solr releases prior to 7.4 (i.e. Solr 5, Solr 6, and Solr 7 through 7.3) 
 
 Solr's Prometheus Exporter uses Log4J as well but it does not log user input or data, so we don't see a risk there.
 
+Apache Solr releases are *not* vulnerable to the followup CVE-2021-45046, because the MDC patterns used by Solr are for the
+collection, shard, replica, core and node names, and a potential trace id, which are all sanitized. The other attack vectors
+cannot be used with Solr. Passing system property `log4j2.formatMsgNoLookups=true` (as described below) is suitable to mitigate.
+
 **Mitigation:**
 Any of the following are enough to prevent this vulnerability for Solr servers:
 
-* Upgrade to `Solr 8.11.1` or greater (when available), which will include an updated version of the Log4J dependency.
+* Upgrade to `Solr 8.11.1` or greater (when available), which will include an updated version (2.16.0) of the Log4J dependency.
 * If you are using Solr's official docker image, it has already been mitigated in all versions listed as supported on Docker Hub: <https://hub.docker.com/_/solr>.  You may need to re-pull the image.
 * Manually update the version of Log4J on your runtime classpath and restart your Solr application.
 * (Linux/MacOS) Edit your `solr.in.sh` file to include:

--- a/content/solr/security/2021-12-10-cve-2021-44228.md
+++ b/content/solr/security/2021-12-10-cve-2021-44228.md
@@ -16,8 +16,8 @@ Apache Solr releases prior to 7.4 (i.e. Solr 5, Solr 6, and Solr 7 through 7.3) 
 Solr's Prometheus Exporter uses Log4J as well but it does not log user input or data, so we don't see a risk there.
 
 Apache Solr releases are *not* vulnerable to the followup CVE-2021-45046, because the MDC patterns used by Solr are for the
-collection, shard, replica, core and node names, and a potential trace id, which are all sanitized. The other attack vectors
-cannot be used with Solr. Passing system property `log4j2.formatMsgNoLookups=true` (as described below) is suitable to mitigate.
+collection, shard, replica, core and node names, and a potential trace id, which are all sanitized. The other mentioned attack vectors
+cannot be used with Solr, too. Passing system property `log4j2.formatMsgNoLookups=true` (as described below) is suitable to mitigate.
 
 **Mitigation:**
 Any of the following are enough to prevent this vulnerability for Solr servers:

--- a/content/solr/security/2021-12-10-cve-2021-44228.md
+++ b/content/solr/security/2021-12-10-cve-2021-44228.md
@@ -16,13 +16,13 @@ Apache Solr releases prior to 7.4 (i.e. Solr 5, Solr 6, and Solr 7 through 7.3) 
 Solr's Prometheus Exporter uses Log4J as well but it does not log user input or data, so we don't see a risk there.
 
 Apache Solr releases are *not* vulnerable to the followup CVE-2021-45046, because the MDC patterns used by Solr are for the
-collection, shard, replica, core and node names, and a potential trace id, which are all sanitized. The other mentioned attack vectors
-cannot be used with Solr, too. Passing system property `log4j2.formatMsgNoLookups=true` (as described below) is suitable to mitigate.
+collection, shard, replica, core and node names, and a potential trace id, which are all sanitized. Passing system property
+`log4j2.formatMsgNoLookups=true` (as described below) is suitable to mitigate.
 
 **Mitigation:**
 Any of the following are enough to prevent this vulnerability for Solr servers:
 
-* Upgrade to `Solr 8.11.1` or greater (when available), which will include an updated version (2.16.0) of the Log4J dependency.
+* Upgrade to `Solr 8.11.1` or greater (when available), which will include an updated version (`>= 2.16.0`) of the Log4J dependency.
 * If you are using Solr's official docker image, it has already been mitigated in all versions listed as supported on Docker Hub: <https://hub.docker.com/_/solr>.  You may need to re-pull the image.
 * Manually update the version of Log4J on your runtime classpath and restart your Solr application.
 * (Linux/MacOS) Edit your `solr.in.sh` file to include:


### PR DESCRIPTION
This adds a note about the followup CVE-2021-45046 and makes clear that SOlr is not affected.