### PR TITLE
Log4shell: Justify log4j2.formatMsgNoLookups (#62)

### DIFF
--- a/content/solr/security/2021-12-10-cve-2021-44228.md
+++ b/content/solr/security/2021-12-10-cve-2021-44228.md
@@ -15,10 +15,7 @@ Apache Solr releases prior to 7.4 (i.e. Solr 5, Solr 6, and Solr 7 through 7.3) 
 
 Solr's Prometheus Exporter uses Log4J as well but it does not log user input or data, so we don't see a risk there.
 
-Apache Solr releases are *not* vulnerable to the followup **CVE-2021-45046** and **CVE-2021-45105**, because the MDC patterns used by Solr
-are for the collection, shard, replica, core and node names, and a potential trace id, which are all sanitized
-and injected into log files with "`%X`". Passing system property `log4j2.formatMsgNoLookups=true` (as described below)
-is suitable to mitigate.
+Solr is *not* vulnerable to the followup **CVE-2021-45046** and **CVE-2021-45105**.  A listing of these and other CVEs with some justifications are listed in Solr's wiki: https://cwiki.apache.org/confluence/display/SOLR/SolrSecurity#SolrSecurity-SolrandVulnerabilityScanningTools
 
 **Mitigation:**
 Any of the following are enough to prevent this vulnerability for Solr servers:
@@ -31,6 +28,10 @@ Any of the following are enough to prevent this vulnerability for Solr servers:
 * (Windows) Edit your `solr.in.cmd` file to include:
   `set SOLR_OPTS=%SOLR_OPTS% -Dlog4j2.formatMsgNoLookups=true`
 * Follow any of the other mitgations listed at <https://logging.apache.org/log4j/2.x/security.html>
+
+The Log4J security page refers to setting `log4j2.formatMsgNoLookups=true` as a "discredited" mitigation.  In reality, it depends.
+We've looked at the root cause and audited the code paths that lead to the vulnerability, and we feel confident in this mitigation being sufficient for Solr.
+See <https://lists.apache.org/thread/kgh63sncrsm2bls884pg87mnt8vqztmz> for discussion.
 
 **References:**
 <https://logging.apache.org/log4j/2.x/security.html>


### PR DESCRIPTION
and refer to the Wiki for some more explanations.