### PR TITLE
Redirect Apache CRDs to the archives instead of nightlies

### DIFF
--- a/themes/solr/templates/htaccess.template
+++ b/themes/solr/templates/htaccess.template
@@ -71,7 +71,7 @@ RedirectMatch Permanent ^/docs/api-(.*) /docs/$1
 
 ### Redirects to Apache Nightlies, this will change when they have a separate area for released artifacts
 Redirect temp /charts https://nightlies.apache.org/solr/release/helm-charts
-### Redirects to Github Releases for pre-Apache Solr Operator CRDs
+### Redirects to Apache Nightlies for pre-Apache Solr Operator CRDs (These don't exist in the archives)
 RedirectMatch ^/operator/downloads/crds/(v0\.2\.6|v0\.2\.7|v0\.2\.8) https://nightlies.apache.org/solr/release/operator/crds/$1
 ### Redirects to Apache Archives, where the official release CRDs are stored
 RedirectMatch ^/operator/downloads/crds/(v\d+\.\d+\.\d+) https://archive.apache.org/dist/solr/solr-operator/$1/crds

--- a/themes/solr/templates/htaccess.template
+++ b/themes/solr/templates/htaccess.template
@@ -74,7 +74,7 @@ Redirect temp /charts https://nightlies.apache.org/solr/release/helm-charts
 ### Redirects to Apache Nightlies for pre-Apache Solr Operator CRDs (These don't exist in the archives)
 RedirectMatch ^/operator/downloads/crds/(v0\.2\.6|v0\.2\.7|v0\.2\.8) https://nightlies.apache.org/solr/release/operator/crds/$1
 ### Redirects to Apache Archives, where the official release CRDs are stored
-RedirectMatch ^/operator/downloads/crds/(v\d+\.\d+\.\d+) https://archive.apache.org/dist/solr/solr-operator/$1/crds
+RedirectMatch ^/operator/downloads/crds/(v\d+\.\d+\.\d+) https://www.apache.org/dyn/closer.lua?action=download&filename=/solr/solr-operator/$1/crds
 
 ### Javadocs & Refguide
 

--- a/themes/solr/templates/htaccess.template
+++ b/themes/solr/templates/htaccess.template
@@ -71,7 +71,10 @@ RedirectMatch Permanent ^/docs/api-(.*) /docs/$1
 
 ### Redirects to Apache Nightlies, this will change when they have a separate area for released artifacts
 Redirect temp /charts https://nightlies.apache.org/solr/release/helm-charts
-Redirect temp /operator/downloads/crds https://nightlies.apache.org/solr/release/operator/crds
+### Redirects to Github Releases for pre-Apache Solr Operator CRDs
+RedirectMatch ^/operator/downloads/crds/(v0\.2\.6|v0\.2\.7|v0\.2\.8) https://nightlies.apache.org/solr/release/operator/crds/$1
+### Redirects to Apache Archives, where the official release CRDs are stored
+RedirectMatch ^/operator/downloads/crds/(v\d+\.\d+\.\d+) https://archive.apache.org/dist/solr/solr-operator/$1/crds
 
 ### Javadocs & Refguide
 


### PR DESCRIPTION
Nightlies has been shown to not be stable today, so we need to move the CRD redirect to the archives. (Older non-apache releases are not in the archives, so we will continue to redirect those to the nightlies server)

We also need to move the helm charts, but that can be done separately.