### PR TITLE
Use the website as the host of the Solr Helm Repo

### DIFF
--- a/content/charts/artifacthub-repo.yml
+++ b/content/charts/artifacthub-repo.yml
@@ -1,0 +1,5 @@
+# Artifact Hub repository metadata file
+repositoryID: 94eedfc1-e8df-4f3f-81ba-138b632c41a2
+owners: # (optional, used to claim repository ownership)
+  - name: Apache Solr PMC
+    email: private@solr.apache.org

--- a/content/charts/index.yaml
+++ b/content/charts/index.yaml
@@ -1,0 +1,1064 @@
+apiVersion: v1
+entries:
+  solr:
+    - annotations:
+        artifacthub.io/changes: |
+          - kind: changed
+            description: The minimum supported version for Kubernetes is now v1.19.
+            links:
+              - name: Github Issue
+                url: https://github.com/apache/solr-operator/issues/277
+              - name: Github PR
+                url: https://github.com/apache/solr-operator/pull/321
+          - kind: deprecated
+            description: The legacy backup options (dataStorage.backupRestoreOptions) have been deprecated. Please use backupRepositories instead.
+            links:
+              - name: Github Issue
+                url: https://github.com/apache/solr-operator/issues/301
+              - name: Github PR
+                url: https://github.com/apache/solr-operator/pull/302
+              - name: Backup Documentation
+                url: https://apache.github.io/solr-operator/docs/solr-backup/
+        artifacthub.io/containsSecurityUpdates: "false"
+        artifacthub.io/images: |
+          - name: solr
+            image: solr:8.9
+            whitelisted: true
+        artifacthub.io/links: |
+          - name: "Solr Source"
+            url: https://github.com/apache/solr
+          - name: "Helm Chart Source"
+            url: https://github.com/apache/solr-operator
+          - name: "Solr Documentation"
+            url: https://solr.apache.org/guide/
+          - name: "Solr on Kube Tutorials"
+            url: https://solr.apache.org/operator/resources#tutorials
+        artifacthub.io/operator: "false"
+        artifacthub.io/prerelease: "false"
+        artifacthub.io/recommendations: |
+          - url: https://artifacthub.io/packages/helm/apache-solr/solr-operator
+        artifacthub.io/signKey: |
+          fingerprint: 50E3EE1C91C7E0CB4DFB007B369424FC98F3F6EC
+          url: https://dist.apache.org/repos/dist/release/solr/KEYS
+      apiVersion: v2
+      appVersion: 8.9.0
+      created: "2021-11-16T17:45:58.964581-05:00"
+      description: A SolrCloud cluser running on Kubernetes via the Solr Operator
+      digest: 821bf7f056ba46c44959e0e4024c539ae1cfd4a38cb55b80d113f785b2d87d9b
+      home: https://solr.apache.org
+      icon: https://solr.apache.org/theme/images/identity/Solr_Logo_on_white.png
+      keywords:
+        - solr
+        - apache
+        - search
+        - lucene
+      kubeVersion: '>= 1.19.0-0'
+      maintainers:
+        - email: dev@solr.apache.org
+          name: Solr Dev Community
+        - email: houston@apache.org
+          name: Houston Putman
+      name: solr
+      sources:
+        - https://github.com/apache/solr
+        - https://github.com/apache/solr-operator
+      urls:
+        - solr-0.5.0.tgz
+      version: 0.5.0
+    - annotations:
+        artifacthub.io/changes: |
+          - kind: added
+            description: Official Solr Helm chart created. Works with the Solr Operator.
+            links:
+              - name: Github Issue
+                url: https://github.com/apache/solr-operator/issues/112
+              - name: Github PR
+                url: https://github.com/apache/solr-operator/pull/276
+          - kind: changed
+            description: Default Solr Version upgraded to 8.9, does not affect existing clouds
+            links:
+              - name: Github Issue
+                url: https://github.com/apache/solr-operator/issues/285
+              - name: Github PR
+                url: https://github.com/apache/solr-operator/pull/287
+          - kind: added
+            description: Ability to create serviceAccount for SolrCloud deployment through Helm chart.
+            links:
+              - name: Github Issue
+                url: https://github.com/apache/solr-operator/issues/264
+              - name: Github PR
+                url: https://github.com/apache/solr-operator/pull/283
+        artifacthub.io/containsSecurityUpdates: "false"
+        artifacthub.io/images: |
+          - name: solr
+            image: solr:8.9
+            whitelisted: true
+        artifacthub.io/links: |
+          - name: "Solr Source"
+            url: https://github.com/apache/solr
+          - name: "Helm Chart Source"
+            url: https://github.com/apache/solr-operator
+          - name: "Solr Documentation"
+            url: https://solr.apache.org/guide/
+          - name: "Solr on Kube Tutorials"
+            url: https://solr.apache.org/operator/resources#tutorials
+        artifacthub.io/operator: "false"
+        artifacthub.io/prerelease: "false"
+        artifacthub.io/recommendations: |
+          - url: https://artifacthub.io/packages/helm/apache-solr/solr-operator
+        artifacthub.io/signKey: |
+          fingerprint: 50E3EE1C91C7E0CB4DFB007B369424FC98F3F6EC
+          url: https://dist.apache.org/repos/dist/release/solr/KEYS
+      apiVersion: v2
+      appVersion: 8.9.0
+      created: "2021-09-13T12:49:36.724795-04:00"
+      description: A SolrCloud cluser running on Kubernetes via the Solr Operator
+      digest: b004e8abcc6d30139d0d59b966a8c47d6cae42585c6d735c49ce7eaed76590c3
+      home: https://solr.apache.org
+      icon: https://solr.apache.org/theme/images/identity/Solr_Logo_on_white.png
+      keywords:
+        - solr
+        - apache
+        - search
+        - lucene
+      kubeVersion: '>= 1.16.0-0'
+      maintainers:
+        - email: dev@solr.apache.org
+          name: Solr Dev Community
+        - email: houston@apache.org
+          name: Houston Putman
+      name: solr
+      sources:
+        - https://github.com/apache/solr
+        - https://github.com/apache/solr-operator
+      urls:
+        - solr-0.4.0.tgz
+      version: 0.4.0
+  solr-operator:
+    - annotations:
+        artifacthub.io/changes: |
+          - kind: changed
+            description: The minimum supported version for Kubernetes is now v1.19. The Solr Operator is no longer using deprecated APIs, such as networking.k8s.io/v1beta1 for Ingresses.
+            links:
+              - name: Github Issue
+                url: https://github.com/apache/solr-operator/issues/277
+              - name: Github PR
+                url: https://github.com/apache/solr-operator/pull/321
+          - kind: changed
+            description: The Solr Operator has upgraded its Kubebuilder dependency to v3.
+            links:
+              - name: Bug Report Issue
+                url: https://github.com/apache/solr-operator/issues/320
+              - name: Github PR
+                url: https://github.com/apache/solr-operator/pull/321
+          - kind: fixed
+            description: The SolrPrometheusExporter controller now watches for changes in referenced Solr Clouds, so the referenced ZKConnectionString is updated if it changes within the SolrCloud status.
+            links:
+              - name: Bug Report Issue
+                url: https://github.com/apache/solr-operator/issues/325
+              - name: Github PR (Large and almost entirely unrelated)
+                url: https://github.com/apache/solr-operator/pull/321
+          - kind: deprecated
+            description: The legacy backup options (SolrCloud.spec.dataStorage.backupRestoreOptions) have been deprecated. Please use SolrCloud.spec.backupRepositories instead.
+            links:
+              - name: Github Issue
+                url: https://github.com/apache/solr-operator/issues/301
+              - name: Github PR
+                url: https://github.com/apache/solr-operator/pull/302
+              - name: Backup Documentation
+                url: https://apache.github.io/solr-operator/docs/solr-backup/
+          - kind: added
+            description: Introduced the ability to use GCS Backup Repositories with SolrCloud and SolrBackup.
+            links:
+              - name: Github Issue
+                url: https://github.com/apache/solr-operator/issues/301
+              - name: Github PR
+                url: https://github.com/apache/solr-operator/pull/302
+              - name: Backup Documentation
+                url: https://apache.github.io/solr-operator/docs/solr-backup#gcs-backup-repositories
+          - kind: added
+            description: Introduced the ability to use S3 Backup Repositories with SolrCloud and SolrBackup.
+            links:
+              - name: Github Issue
+                url: https://github.com/apache/solr-operator/issues/328
+              - name: Github PR
+                url: https://github.com/apache/solr-operator/pull/345
+              - name: Solr S3 Repository Documentation
+                url: https://solr.apache.org/guide/8_10/making-and-restoring-backups.html#s3backuprepository
+              - name: Backup Documentation
+                url: https://apache.github.io/solr-operator/docs/solr-backup#s3-backup-repositories
+          - kind: added
+            description: Customize the Lifecycle for Solr and PrometheusExporter containers
+            links:
+              - name: Github Issue
+                url: https://github.com/apache/solr-operator/issues/322
+              - name: Github PR
+                url: https://github.com/apache/solr-operator/pull/324
+          - kind: added
+            description: Add support for using Solr Modules (contrib) and additional libraries
+            links:
+              - name: Github Issue
+                url: https://github.com/apache/solr-operator/issues/329
+              - name: Github PR
+                url: https://github.com/apache/solr-operator/pull/332
+              - name: Solr Modules
+                url: https://github.com/apache/solr/tree/main/solr/contrib
+          - kind: added
+            description: SolrBackups can now have a custom location specified to store the backup
+            links:
+              - name: Github PR
+                url: https://github.com/apache/solr-operator/pull/345
+          - kind: fixed
+            description: Fix for managed restarts across connected SolrCloud resources.
+            links:
+              - name: Github Issue
+                url: https://github.com/apache/solr-operator/issues/348
+              - name: Github PR
+                url: https://github.com/apache/solr-operator/pull/349
+          - kind: added
+            description: Ability to use topologySpreadConstraints for SolrCloud and SolrPrometheusExporter
+            links:
+              - name: Github Issue
+                url: https://github.com/apache/solr-operator/issues/53
+              - name: Github PR
+                url: https://github.com/apache/solr-operator/pull/350
+              - name: Topology Spread Constraints Documentation
+                url: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/
+          - kind: added
+            description: Ability to bootstrap security configuration from a security.json in a user-supplied secret
+            links:
+              - name: Github Issue
+                url: https://github.com/apache/solr-operator/issues/355
+              - name: Github PR
+                url: https://github.com/apache/solr-operator/pull/356
+          - kind: added
+            description: Export default Solr Operator metrics, and enable when using the Helm chart
+            links:
+              - name: Github Issue
+                url: https://github.com/apache/solr-operator/issues/307
+              - name: Github PR
+                url: https://github.com/apache/solr-operator/pull/360
+          - kind: added
+            description: Ability to set the IngressClassName for v1 Ingress resources.
+            links:
+              - name: Github Issue (Ingress v1)
+                url: https://github.com/apache/solr-operator/issues/277
+              - name: Github PR
+                url: https://github.com/apache/solr-operator/pull/363
+          - kind: removed
+            description: Removed "persistence" option for SolrBackups. Instead please use the S3 or GCP Backup Repositories (Solr 8.9+)
+            links:
+              - name: Github Issue
+                url: https://github.com/apache/solr-operator/issues/347
+              - name: Github PR
+                url: https://github.com/apache/solr-operator/pull/357
+          - kind: added
+            description: Support for more Zookeeper Pod customization options
+            links:
+              - name: Github Issue
+                url: https://github.com/apache/solr-operator/issues/352
+              - name: Github PR
+                url: https://github.com/apache/solr-operator/pull/361
+          - kind: added
+            description: Separate SolrCloud backup ready status by backup repository
+            links:
+              - name: Github Issue
+                url: https://github.com/apache/solr-operator/issues/326
+              - name: Github PR
+                url: https://github.com/apache/solr-operator/pull/358
+          - kind: added
+            description: Scheduled/Recurring SolrBackup support
+            links:
+              - name: Github Issue
+                url: https://github.com/apache/solr-operator/issues/303
+              - name: Github PR
+                url: https://github.com/apache/solr-operator/pull/359
+              - name: SolrBackup Documentation
+                url: https://apache.github.io/solr-operator/docs/solr-backup#recurring-backups
+          - kind: changed
+            description: Solr Operator Leader Election enabled by default
+            links:
+              - name: Github Issue
+                url: https://github.com/apache/solr-operator/issues/366
+              - name: Github PR
+                url: https://github.com/apache/solr-operator/pull/367
+        artifacthub.io/containsSecurityUpdates: "false"
+        artifacthub.io/crds: |
+          - kind: SolrCloud
+            version: v1beta1
+            name: solrcloud.solr.apache.org
+            displayName: Solr Cloud
+            description: A distributed Solr Cloud cluster
+          - kind: SolrPrometheusExporter
+            version: v1beta1
+            name: solrprometheusexporter.solr.apache.org
+            displayName: Solr Prometheus Exporter
+            description: A Prometheus metrics exporter for Solr
+          - kind: SolrBackup
+            version: v1beta1
+            name: solrbackup.solr.apache.org
+            displayName: Solr Backup
+            description: A backup mechanism for Solr
+        artifacthub.io/crdsExamples: |
+          - apiVersion: solr.apache.org/v1beta1
+            kind: SolrCloud
+            metadata:
+              name: example
+            spec:
+              dataStorage:
+                persistent:
+                  reclaimPolicy: Delete
+                  pvcTemplate:
+                    spec:
+                      resources:
+                        requests:
+                          storage: "20Gi"
+              replicas: 3
+              solrImage:
+                tag: 8.7.0
+              solrJavaMem: "-Xms4g -Xmx4g"
+              customSolrKubeOptions:
+                podOptions:
+                  resources:
+                    requests:
+                      memory: "6G"
+              zookeeperRef:
+                provided:
+                  replicas: 3
+              solrOpts: "-Dsolr.autoSoftCommit.maxTime=10000"
+              solrGCTune: "-XX:SurvivorRatio=4 -XX:TargetSurvivorRatio=90 -XX:MaxTenuringThreshold=8"
+              backupRepositories:
+                - name: default-gcs
+                  gcs:
+                    bucket: solr-gcs-backups
+                    gcsCredentialSecret: # Required
+                      name: gcs-credentials
+                      key: "service-account-key.json"
+                    baseLocation: "/solrcloud/backups"
+                - name: default-s3
+                  s3:
+                    region: us-west-2
+                    bucket: solr-s3-backups
+                    credentials:
+                      accessKeyIdSecret: # Optional
+                        name: aws-secrets
+                        key: access-key-id
+                      secretAccessKeySecret: # Optional
+                        name: aws-secrets
+                        key: secret-access-key
+          - apiVersion: solr.apache.org/v1beta1
+            kind: SolrPrometheusExporter
+            metadata:
+              name: example
+            spec:
+              solrReference:
+                cloud:
+                  name: "example"
+              numThreads: 4
+              image:
+                tag: 8.7.0
+          - apiVersion: solr.apache.org/v1beta1
+            kind: SolrPrometheusExporter
+            metadata:
+              name: example
+            spec:
+              solrReference:
+                cloud:
+                  name: "example"
+              numThreads: 4
+              image:
+                tag: 8.7.0
+          - apiVersion: solr.apache.org/v1beta1
+            kind: SolrBackup
+            metadata:
+              name: example
+            spec:
+              repositoryName: solr-gcs-backups
+              solrCloud: example
+              collections:
+                - techproducts
+                - books
+              location: "/this/location"
+        artifacthub.io/images: |
+          - name: solr-operator
+            image: apache/solr-operator:v0.5.0
+        artifacthub.io/links: |
+          - name: "Tutorials"
+            url: https://solr.apache.org/operator/resources#tutorials
+        artifacthub.io/operator: "true"
+        artifacthub.io/operatorCapabilities: Full Lifecycle
+        artifacthub.io/prerelease: "false"
+        artifacthub.io/recommendations: |
+          - url: https://artifacthub.io/packages/helm/apache-solr/solr
+        artifacthub.io/signKey: |
+          fingerprint: 50E3EE1C91C7E0CB4DFB007B369424FC98F3F6EC
+          url: https://dist.apache.org/repos/dist/release/solr/KEYS
+      apiVersion: v2
+      appVersion: v0.5.0
+      created: "2021-11-16T17:45:58.973569-05:00"
+      dependencies:
+        - condition: zookeeper-operator.install
+          name: zookeeper-operator
+          repository: https://charts.pravega.io
+          version: 0.2.12
+      description: The Solr Operator enables easy management of Solr resources within
+        Kubernetes.
+      digest: 5ceeea0ba48f280cf25a92d63fe5d06e298640e683f4d8fea647fabc045d9a2c
+      home: https://solr.apache.org/operator
+      icon: https://solr.apache.org/theme/images/identity/Solr_Logo_on_white.png
+      keywords:
+        - solr
+        - apache
+        - search
+        - lucene
+        - operator
+      kubeVersion: '>= 1.19.0-0'
+      maintainers:
+        - email: dev@solr.apache.org
+          name: Solr Dev Community
+        - email: houston@apache.org
+          name: Houston Putman
+      name: solr-operator
+      sources:
+        - https://github.com/apache/solr-operator
+      urls:
+        - solr-operator-0.5.0.tgz
+      version: 0.5.0
+    - annotations:
+        artifacthub.io/changes: |
+          - kind: changed
+            description: Zookeeper Operator supported version changed to v0.2.12
+            links:
+              - name: Github Issue
+                url: https://github.com/apache/solr-operator/issues/271
+              - name: Github PR
+                url: https://github.com/apache/solr-operator/pull/304
+              - name: Zookeeper Operator Release Notes
+                url: https://github.com/pravega/zookeeper-operator/releases/tag/v0.2.12
+          - kind: added
+            description: Ability to schedule automatic restarts for SolrClouds
+            links:
+              - name: Github Issue
+                url: https://github.com/apache/solr-operator/issues/281
+              - name: Github PR
+                url: https://github.com/apache/solr-operator/pull/279
+          - kind: added
+            description: Ability to use HostPath volumes for ephemeral Solr storage
+            links:
+              - name: Github Issue
+                url: https://github.com/apache/solr-operator/issues/266
+              - name: Github PR
+                url: https://github.com/apache/solr-operator/pull/265
+          - kind: removed
+            description: "Removed deprecated Solr Operator Helm chart option `useZkOperator`, use `zookeeper-operator.use` instead"
+            links:
+              - name: Github Issue
+                url: https://github.com/apache/solr-operator/issues/286
+              - name: Github PR
+                url: https://github.com/apache/solr-operator/pull/288
+              - name: Deprecating Github PR
+                url: https://github.com/apache/solr-operator/pull/231
+          - kind: changed
+            description: Default Solr Version upgraded to 8.9, does not affect existing clouds
+            links:
+              - name: Github Issue
+                url: https://github.com/apache/solr-operator/issues/285
+              - name: Github PR
+                url: https://github.com/apache/solr-operator/pull/287
+          - kind: added
+            description: Customize serviceAccountName for SolrCloud and SolrPrometheusExporter
+            links:
+              - name: Github Issue
+                url: https://github.com/apache/solr-operator/issues/264
+              - name: Github PR
+                url: https://github.com/apache/solr-operator/pull/283
+          - kind: added
+            description: Introduced ephemeral option for Zookeeper storage
+            links:
+              - name: Github Issue
+                url: https://github.com/apache/solr-operator/issues/259
+              - name: Github PR
+                url: https://github.com/apache/solr-operator/pull/284
+          - kind: security
+            description: Changed Solr Operator base Docker image to reduce vulnerabilities.
+            links:
+              - name: Github Issue
+                url: https://github.com/apache/solr-operator/issues/294
+              - name: Github PR
+                url: https://github.com/apache/solr-operator/pull/295
+          - kind: added
+            description: Ability to customize probes for PrometheusExporter
+            links:
+              - name: Github Issue
+                url: https://github.com/apache/solr-operator/issues/282
+              - name: Github PR
+                url: https://github.com/apache/solr-operator/pull/297
+          - kind: security
+            description: Remove users role from the all permission in the initial security.json
+            links:
+              - name: Github Issue
+                url: https://github.com/apache/solr-operator/issues/274
+              - name: Github PR
+                url: https://github.com/apache/solr-operator/pull/299
+          - kind: fixed
+            description: Grant access to the /admin/zookeeper/status path to the k8s role in the initial security.json
+            links:
+              - name: Github Issue
+                url: https://github.com/apache/solr-operator/issues/289
+              - name: Github PR
+                url: https://github.com/apache/solr-operator/pull/299
+          - kind: security
+            description: Add a mountedServerTLSDir config option to support a unique certificate per pod mounted dynamically by an external agent or CSI driver
+            links:
+              - name: Github Issue
+                url: https://github.com/apache/solr-operator/issues/291
+              - name: Github PR
+                url: https://github.com/apache/solr-operator/pull/292
+          - kind: added
+            description: Ability to terminate TLS at Ingress for SolrCloud.
+            links:
+              - name: Github Issue
+                url: https://github.com/apache/solr-operator/issues/268
+              - name: Github PR
+                url: https://github.com/apache/solr-operator/pull/293
+          - kind: added
+            description: Ability to schedule automatic restarts for SolrPrometheusExporters
+            links:
+              - name: Github Issue
+                url: https://github.com/apache/solr-operator/issues/310
+              - name: Github PR
+                url: https://github.com/apache/solr-operator/pull/313
+          - kind: added
+            description: Ability to specify ZK Config properties for provided Zookeeper Clusters.
+            links:
+              - name: Github Issue
+                url: https://github.com/apache/solr-operator/issues/290
+              - name: Github PR
+                url: https://github.com/apache/solr-operator/pull/311
+          - kind: added
+            description: Option to watch for updates to the mTLS client certificate used by the operator to call Solr pods.
+            links:
+              - name: Github Issue
+                url: https://github.com/apache/solr-operator/issues/317
+              - name: Github PR
+                url: https://github.com/apache/solr-operator/pull/318
+          - kind: added
+            description: Configuration options to support an additional client TLS cert in addition to the server certificate
+            links:
+              - name: Github Issue
+                url: https://github.com/apache/solr-operator/issues/300
+              - name: Github PR
+                url: https://github.com/apache/solr-operator/pull/312
+        artifacthub.io/crds: |
+          - kind: SolrCloud
+            version: v1beta1
+            name: solrcloud.solr.apache.org
+            displayName: Solr Cloud
+            description: A distributed Solr Cloud cluster
+          - kind: SolrPrometheusExporter
+            version: v1beta1
+            name: solrprometheusexporter.solr.apache.org
+            displayName: Solr Prometheus Exporter
+            description: A Prometheus metrics exporter for Solr
+          - kind: SolrBackup
+            version: v1beta1
+            name: solrbackup.solr.apache.org
+            displayName: Solr Backup
+            description: A backup mechanism for Solr
+        artifacthub.io/crdsExamples: |
+          - apiVersion: solr.apache.org/v1beta1
+            kind: SolrCloud
+            metadata:
+              name: example
+            spec:
+              dataStorage:
+                persistent:
+                  reclaimPolicy: Delete
+                  pvcTemplate:
+                    spec:
+                      resources:
+                        requests:
+                          storage: "20Gi"
+              replicas: 3
+              solrImage:
+                tag: 8.7.0
+              solrJavaMem: "-Xms4g -Xmx4g"
+              customSolrKubeOptions:
+                podOptions:
+                  resources:
+                    requests:
+                      memory: "6G"
+              zookeeperRef:
+                provided:
+                  replicas: 3
+              solrOpts: "-Dsolr.autoSoftCommit.maxTime=10000"
+              solrGCTune: "-XX:SurvivorRatio=4 -XX:TargetSurvivorRatio=90 -XX:MaxTenuringThreshold=8"
+          - apiVersion: solr.apache.org/v1beta1
+            kind: SolrPrometheusExporter
+            metadata:
+              name: example
+            spec:
+              solrReference:
+                cloud:
+                  name: "example"
+              numThreads: 4
+              image:
+                tag: 8.7.0
+        artifacthub.io/images: |
+          - name: solr-operator
+            image: apache/solr-operator:v0.4.0
+        artifacthub.io/links: |
+          - name: "Tutorials"
+            url: https://solr.apache.org/operator/resources#tutorials
+        artifacthub.io/operator: "true"
+        artifacthub.io/operatorCapabilities: Seamless Upgrades
+        artifacthub.io/prerelease: "false"
+        artifacthub.io/recommendations: |
+          - url: https://artifacthub.io/packages/helm/apache-solr/solr
+        artifacthub.io/signKey: |
+          fingerprint: 50E3EE1C91C7E0CB4DFB007B369424FC98F3F6EC
+          url: https://dist.apache.org/repos/dist/release/solr/KEYS
+      apiVersion: v2
+      appVersion: v0.4.0
+      created: "2021-09-13T09:09:04.673575-04:00"
+      dependencies:
+        - condition: zookeeper-operator.install
+          name: zookeeper-operator
+          repository: https://charts.pravega.io
+          version: 0.2.12
+      description: The Solr Operator enables easy management of Solr resources within
+        Kubernetes.
+      digest: 3d0a5236a0f578b34bfa8aa5de066cc7dedcdbb153ff325d8b5d815c53cb4cbf
+      home: https://solr.apache.org/operator
+      icon: https://solr.apache.org/theme/images/identity/Solr_Logo_on_white.png
+      keywords:
+        - solr
+        - apache
+        - search
+        - lucene
+        - operator
+      kubeVersion: '>= 1.16.0-0'
+      maintainers:
+        - email: dev@solr.apache.org
+          name: Solr Dev Community
+        - email: houston@apache.org
+          name: Houston Putman
+      name: solr-operator
+      sources:
+        - https://github.com/apache/solr-operator
+      urls:
+        - solr-operator-0.4.0.tgz
+      version: 0.4.0
+    - annotations:
+        artifacthub.io/changes: |
+          - The Solr Operator is now an Apache project managed by the Apache Solr PMC
+          - The Solr CRDs now use the solr.apache.org API group instead of solr.bloomberg.com
+          - The Solr Operator now fully supports running Solr in a secure and locked down way
+          - Basic Auth support is now built in when requested in the SolrCloud CRD
+          - Solr can be run with TLS, with optional mTLS if provided to the operator
+          - More helm chart options are provided to customize running the Solr Operator
+          - The Zookeeper Operator is now up-to-date with the most recent release, v0.2.9
+          - The Zookeeper Operator can now be installed as a helm-chart dependency with the Solr Operator
+          - Users can now provide custom Solr log4j.xml and Prometheus Exporter config xml configMaps
+          - Fix bug in custom probes for Solr pods
+          - Solr pod shutdown is more graceful, has better coordination between Kubernetes and Solr
+          - SolrCloud can now be used with the Kubernetes HPA to autoscale Solr Cloud pods
+        artifacthub.io/crds: |
+          - kind: SolrCloud
+            version: v1beta1
+            name: solrcloud.solr.apache.org
+            displayName: Solr Cloud
+            description: A distributed Solr Cloud cluster
+          - kind: SolrPrometheusExporter
+            version: v1beta1
+            name: solrprometheusexporter.solr.apache.org
+            displayName: Solr Prometheus Exporter
+            description: A Prometheus metrics exporter for Solr
+          - kind: SolrBackup
+            version: v1beta1
+            name: solrbackup.solr.apache.org
+            displayName: Solr Backup
+            description: A backup mechanism for Solr
+        artifacthub.io/crdsExamples: |
+          - apiVersion: solr.apache.org/v1beta1
+            kind: SolrCloud
+            metadata:
+              name: example
+            spec:
+              dataStorage:
+                persistent:
+                  reclaimPolicy: Delete
+                  pvcTemplate:
+                    spec:
+                      resources:
+                        requests:
+                          storage: "20Gi"
+              replicas: 3
+              solrImage:
+                tag: 8.7.0
+              solrJavaMem: "-Xms4g -Xmx4g"
+              customSolrKubeOptions:
+                podOptions:
+                  resources:
+                    requests:
+                      memory: "6G"
+              zookeeperRef:
+                provided:
+                  replicas: 3
+              solrOpts: "-Dsolr.autoSoftCommit.maxTime=10000"
+              solrGCTune: "-XX:SurvivorRatio=4 -XX:TargetSurvivorRatio=90 -XX:MaxTenuringThreshold=8"
+          - apiVersion: solr.apache.org/v1beta1
+            kind: SolrPrometheusExporter
+            metadata:
+              name: example
+            spec:
+              solrReference:
+                cloud:
+                  name: "example"
+              numThreads: 4
+              image:
+                tag: 8.7.0
+        artifacthub.io/images: |
+          - name: solr-operator
+            image: apache/solr-operator:v0.3.0
+        artifacthub.io/operator: "true"
+        artifacthub.io/operatorCapabilities: Seamless Upgrades
+        artifacthub.io/prerelease: "false"
+      apiVersion: v2
+      appVersion: v0.3.0
+      created: "2021-04-29T13:39:05.588431-05:00"
+      dependencies:
+        - condition: zookeeper-operator.install
+          name: zookeeper-operator
+          repository: https://charts.pravega.io
+          version: 0.2.9
+      description: The Solr Operator enables easy management of Solr resources within
+        Kubernetes.
+      digest: b62a5c33189789a07c59e59c5d4f3072c8c7367c91b8e977e4eb68af9bb16b28
+      home: https://github.com/apache/solr-operator
+      icon: https://solr.apache.org/theme/images/identity/Solr_Logo_on_white.png
+      keywords:
+        - solr
+        - apache
+        - search
+        - lucene
+        - operator
+      kubeVersion: '>= 1.16.0-0'
+      maintainers:
+        - email: dev@solr.apache.org
+          name: Solr Dev Community
+        - email: houston@apache.org
+          name: Houston Putman
+      name: solr-operator
+      sources:
+        - https://github.com/apache/solr-operator
+      urls:
+        - solr-operator-0.3.0.tgz
+      version: 0.3.0
+    - annotations:
+        artifacthub.io/changes: |-
+          - This will be the last release of the Bloomberg Solr Operator.
+            All new versions will be release from the Apache organization.
+          - Fixing upgrade issue with new Status fields
+        artifacthub.io/crds: |
+          - kind: SolrCloud
+            version: v1beta1
+            name: solrcloud.solr.bloomberg.com
+            displayName: Solr Cloud
+            description: A distributed Solr Cloud cluster
+          - kind: SolrPrometheusExporter
+            version: v1beta1
+            name: solrprometheusexporter.solr.bloomberg.com
+            displayName: Solr Prometheus Exporter
+            description: A Prometheus metrics exporter for Solr
+          - kind: SolrBackup
+            version: v1beta1
+            name: solrbackup.solr.bloomberg.com
+            displayName: Solr Backup
+            description: A backup mechanism for Solr
+        artifacthub.io/crdsExamples: |
+          - apiVersion: solr.bloomberg.com/v1beta1
+            kind: SolrCloud
+            metadata:
+              name: example
+            spec:
+              dataStorage:
+                persistent:
+                  reclaimPolicy: Delete
+                  pvcTemplate:
+                    spec:
+                      resources:
+                        requests:
+                          storage: "20Gi"
+              replicas: 3
+              solrImage:
+                tag: 8.7.0
+              solrJavaMem: "-Xms4g -Xmx4g"
+              customSolrKubeOptions:
+                podOptions:
+                  resources:
+                    requests:
+                      memory: "6G"
+              zookeeperRef:
+                provided:
+                  replicas: 3
+              solrOpts: "-Dsolr.autoSoftCommit.maxTime=10000"
+              solrGCTune: "-XX:SurvivorRatio=4 -XX:TargetSurvivorRatio=90 -XX:MaxTenuringThreshold=8"
+          - apiVersion: solr.bloomberg.com/v1beta1
+            kind: SolrPrometheusExporter
+            metadata:
+              name: example
+            spec:
+              solrReference:
+                cloud:
+                  name: "example"
+              numThreads: 4
+              image:
+                tag: 8.7.0
+        artifacthub.io/images: |
+          - name: solr-operator
+            image: bloomberg/solr-operator:v0.2.8
+        artifacthub.io/operator: "true"
+        artifacthub.io/operatorCapabilities: Seamless Upgrades
+        artifacthub.io/prerelease: "false"
+      apiVersion: v1
+      appVersion: v0.2.8
+      created: "2021-01-11T15:21:23.033109-05:00"
+      description: The Solr Operator enables easy management of Solr resources within
+        Kubernetes.
+      digest: 27fcb78a7cf8e76cec6fb99b1aef02224fa25485425266f4e5be20f9b6d04801
+      home: https://github.com/apache/solr-operator
+      icon: https://solr.apache.org/theme/images/identity/Solr_Logo_on_white.png
+      keywords:
+        - solr
+        - apache
+        - search
+        - lucene
+        - operator
+      kubeVersion: '>= 1.16.0-0'
+      maintainers:
+        - email: dev@solr.apache.org
+          name: Solr Dev Community
+        - email: houston@apache.org
+          name: Houston Putman
+      name: solr-operator
+      sources:
+        - https://github.com/apache/solr-operator
+      urls:
+        - solr-operator-0.2.8.tgz
+      version: 0.2.8
+    - annotations:
+        artifacthub.io/changes: |
+          - |
+            Kubernetes 1.16+ is required for for this release of the Solr Operator.
+            Please continue using v0.2.6 until you are able to upgrade your Kubernetes cluster.
+          - Removed support for etcd/zetcd deployments.
+          - Deprecations (All deprecations will be removed in v0.3.0)
+          - |
+            The section for a Zookeeper cluster Spec "SolrCloud.spec.zookeeperRef.provided.zookeeper" has been DEPRECATED.
+            The same fields (except for the deprecated persistentVolumeClaimSpec option) are now available under "SolrCloud.spec.zookeeperRef.provided".
+          - Data Storage options have been expanded, and moved from their old locations.
+          - |
+            "SolrCloud.spec.dataPvcSpec" has been DEPRECATED.
+            Please instead use the following instead: "SolrCloud.spec.dataStorage.persistent.pvcTemplate.spec"
+          - |
+            "SolrCloud.spec.backupRestoreVolume" has been DEPRECATED.
+            Please instead use the following instead: "SolrCloud.spec.dataStorage.backupRestoreOptions.Volume"
+          - The SolrCloud and SolrPrometheusExporter services' portNames have changed to "solr-client" and "solr-metrics" from "ext-solr-client" and "ext-solr-metrics", respectivelyi.
+          - |
+            The default PodManagementPolicy for StatefulSets has been changed to Parallel from OrderedReady.
+            This change will not affect existing StatefulSets, as PodManagementPolicy cannot be updated.
+            In order to continue using OrderedReady on new SolrClouds, please use the following setting:
+            "SolrCloud.spec.customSolrKubeOptions.statefulSetOptions.podManagementPolicy"
+          - The location of backup-restore volume mounts in Solr containers has changed from "/var/solr/solr-backup-restore" to "/var/solr/data/backup-restore".
+          - Introduced a managed SolrCloud update strategy
+          - Added PriorityClassName in podOptions
+          - Added option to provide ZK ACLs
+          - Added dataStorage options for SolrCloud - PVC reclaim policy & Ephemeral Volume spec for non-persistent storage
+          - Ability to provide custom solr.xml for SolrCloud
+          - Ability to specify sidecar container and additional initContainers
+          - Gracefully shutdown Solr nodes using the Solr stop port
+          - Adding scope=Namespaced to all CRDs
+          - Move chroot creation logic to pod postStart and out of operator
+          - Change default SolrCloud podManagementPolicy to Parallel from OrderedReady
+          - ZKConnectionString now uses all ZK hosts with Provided ZK
+          - Fix service port name and status URL bugs
+          - Fix never-ending reconcile loop for ZKs
+          - Fix never-ending reconcile loop for ingresses in Kube 1.18+
+          - SolrBackup now works with Solr 8.6+
+          - Fixed an issue with volume permissions in the read-write-many volume for Backups
+          - Remove default imagePullPolicy for pods
+          - Upgraded CRD versions to v1, from v1beta1
+        artifacthub.io/crds: |
+          - kind: SolrCloud
+            version: v1beta1
+            name: solrcloud.solr.bloomberg.com
+            displayName: Solr Cloud
+            description: A distributed Solr Cloud cluster
+          - kind: SolrPrometheusExporter
+            version: v1beta1
+            name: solrprometheusexporter.solr.bloomberg.com
+            displayName: Solr Prometheus Exporter
+            description: A Prometheus metrics exporter for Solr
+          - kind: SolrBackup
+            version: v1beta1
+            name: solrbackup.solr.bloomberg.com
+            displayName: Solr Backup
+            description: A backup mechanism for Solr
+        artifacthub.io/crdsExamples: |
+          - apiVersion: solr.bloomberg.com/v1beta1
+            kind: SolrCloud
+            metadata:
+              name: example
+            spec:
+              dataStorage:
+                persistent:
+                  reclaimPolicy: Delete
+                  pvcTemplate:
+                    spec:
+                      resources:
+                        requests:
+                          storage: "20Gi"
+              replicas: 3
+              solrImage:
+                tag: 8.7.0
+              solrJavaMem: "-Xms4g -Xmx4g"
+              customSolrKubeOptions:
+                podOptions:
+                  resources:
+                    requests:
+                      memory: "6G"
+              zookeeperRef:
+                provided:
+                  replicas: 3
+              solrOpts: "-Dsolr.autoSoftCommit.maxTime=10000"
+              solrGCTune: "-XX:SurvivorRatio=4 -XX:TargetSurvivorRatio=90 -XX:MaxTenuringThreshold=8"
+          - apiVersion: solr.bloomberg.com/v1beta1
+            kind: SolrPrometheusExporter
+            metadata:
+              name: example
+            spec:
+              solrReference:
+                cloud:
+                  name: "example"
+              numThreads: 4
+              image:
+                tag: 8.7.0
+        artifacthub.io/images: |
+          - name: solr-operator
+            image: bloomberg/solr-operator:v0.2.7
+        artifacthub.io/operator: "true"
+        artifacthub.io/operatorCapabilities: Seamless Upgrades
+        artifacthub.io/prerelease: "false"
+      apiVersion: v1
+      appVersion: v0.2.7
+      created: "2021-01-11T15:21:23.033109-05:00"
+      description: The Solr Operator enables easy management of Solr resources within
+        Kubernetes.
+      digest: 93219551374cbda16be911aed57b86e208072304bafce023fabef39e35e677b1
+      home: https://github.com/apache/solr-operator
+      icon: https://solr.apache.org/theme/images/identity/Solr_Logo_on_white.png
+      keywords:
+        - solr
+        - apache
+        - search
+        - lucene
+        - operator
+      kubeVersion: '>= 1.13.0-0'
+      maintainers:
+        - email: dev@solr.apache.org
+          name: Solr Dev Community
+        - email: houston@apache.org
+          name: Houston Putman
+      name: solr-operator
+      sources:
+        - https://github.com/apache/solr-operator
+      urls:
+        - solr-operator-0.2.7.tgz
+      version: 0.2.7
+    - annotations:
+        artifacthub.io/changes: |
+          - Helm chart fixes and improvements
+          - Adding namespace functionality to operator and helm chart
+          - Adding custom addressability options to solrcloud
+          - Adding configurable liveness, readiness, startup checks
+          - Documentation improvements
+        artifacthub.io/crds: |
+          - kind: SolrCloud
+            version: v1beta1
+            name: solrcloud.solr.bloomberg.com
+            displayName: Solr Cloud
+            description: A distributed Solr Cloud cluster
+          - kind: SolrPrometheusExporter
+            version: v1beta1
+            name: solrprometheusexporter.solr.bloomberg.com
+            displayName: Solr Prometheus Exporter
+            description: A Prometheus metrics exporter for Solr
+          - kind: SolrBackup
+            version: v1beta1
+            name: solrbackup.solr.bloomberg.com
+            displayName: Solr Backup
+            description: A backup mechanism for Solr
+        artifacthub.io/crdsExamples: |
+          - apiVersion: solr.bloomberg.com/v1beta1
+            kind: SolrCloud
+            metadata:
+              name: example
+            spec:
+              replicas: 3
+              solrImage:
+                tag: 8.7.0
+              solrJavaMem: "-Xms4g -Xmx4g"
+              customSolrKubeOptions:
+                podOptions:
+                  resources:
+                    requests:
+                      memory: "6G"
+              solrOpts: "-Dsolr.autoSoftCommit.maxTime=10000"
+              solrGCTune: "-XX:SurvivorRatio=4 -XX:TargetSurvivorRatio=90 -XX:MaxTenuringThreshold=8"
+          - apiVersion: solr.bloomberg.com/v1beta1
+            kind: SolrPrometheusExporter
+            metadata:
+              name: example
+            spec:
+              solrReference:
+                cloud:
+                  name: "example"
+              numThreads: 4
+              image:
+                tag: 8.7.0
+        artifacthub.io/images: |
+          - name: solr-operator
+            image: bloomberg/solr-operator:v0.2.6
+        artifacthub.io/operator: "true"
+        artifacthub.io/operatorCapabilities: Basic Install
+        artifacthub.io/prerelease: "false"
+      apiVersion: v1
+      appVersion: v0.2.6
+      created: "2020-08-10T15:25:32.770735-04:00"
+      description: The Solr Operator enables easy management of Solr resources within
+        Kubernetes.
+      digest: 7c9650262509f1069c74738f4fd9dce4b3eec5198dedf8e710ccb54308756370
+      home: https://github.com/apache/solr-operator
+      icon: https://solr.apache.org/theme/images/identity/Solr_Logo_on_white.png
+      keywords:
+        - solr
+        - apache
+        - search
+        - lucene
+        - operator
+      kubeVersion: '>= 1.13.0-0'
+      maintainers:
+        - email: dev@solr.apache.org
+          name: Solr Dev Community
+        - email: houston@apache.org
+          name: Houston Putman
+        - email: bsankaranara@bloomberg.net
+          name: Balaji Sankaranarayanan
+      name: solr-operator
+      sources:
+        - https://github.com/apache/solr-operator
+      urls:
+        - solr-operator-0.2.6.tgz
+      version: 0.2.6
+generated: "2021-11-16T17:45:58.963106-05:00"

--- a/content/charts/index.yaml
+++ b/content/charts/index.yaml
@@ -1,1064 +1,1064 @@
 apiVersion: v1
 entries:
   solr:
-    - annotations:
-        artifacthub.io/changes: |
-          - kind: changed
-            description: The minimum supported version for Kubernetes is now v1.19.
-            links:
-              - name: Github Issue
-                url: https://github.com/apache/solr-operator/issues/277
-              - name: Github PR
-                url: https://github.com/apache/solr-operator/pull/321
-          - kind: deprecated
-            description: The legacy backup options (dataStorage.backupRestoreOptions) have been deprecated. Please use backupRepositories instead.
-            links:
-              - name: Github Issue
-                url: https://github.com/apache/solr-operator/issues/301
-              - name: Github PR
-                url: https://github.com/apache/solr-operator/pull/302
-              - name: Backup Documentation
-                url: https://apache.github.io/solr-operator/docs/solr-backup/
-        artifacthub.io/containsSecurityUpdates: "false"
-        artifacthub.io/images: |
-          - name: solr
-            image: solr:8.9
-            whitelisted: true
-        artifacthub.io/links: |
-          - name: "Solr Source"
-            url: https://github.com/apache/solr
-          - name: "Helm Chart Source"
-            url: https://github.com/apache/solr-operator
-          - name: "Solr Documentation"
-            url: https://solr.apache.org/guide/
-          - name: "Solr on Kube Tutorials"
-            url: https://solr.apache.org/operator/resources#tutorials
-        artifacthub.io/operator: "false"
-        artifacthub.io/prerelease: "false"
-        artifacthub.io/recommendations: |
-          - url: https://artifacthub.io/packages/helm/apache-solr/solr-operator
-        artifacthub.io/signKey: |
-          fingerprint: 50E3EE1C91C7E0CB4DFB007B369424FC98F3F6EC
-          url: https://dist.apache.org/repos/dist/release/solr/KEYS
-      apiVersion: v2
-      appVersion: 8.9.0
-      created: "2021-11-16T17:45:58.964581-05:00"
-      description: A SolrCloud cluser running on Kubernetes via the Solr Operator
-      digest: 821bf7f056ba46c44959e0e4024c539ae1cfd4a38cb55b80d113f785b2d87d9b
-      home: https://solr.apache.org
-      icon: https://solr.apache.org/theme/images/identity/Solr_Logo_on_white.png
-      keywords:
-        - solr
-        - apache
-        - search
-        - lucene
-      kubeVersion: '>= 1.19.0-0'
-      maintainers:
-        - email: dev@solr.apache.org
-          name: Solr Dev Community
-        - email: houston@apache.org
-          name: Houston Putman
-      name: solr
-      sources:
-        - https://github.com/apache/solr
-        - https://github.com/apache/solr-operator
-      urls:
-        - solr-0.5.0.tgz
-      version: 0.5.0
-    - annotations:
-        artifacthub.io/changes: |
-          - kind: added
-            description: Official Solr Helm chart created. Works with the Solr Operator.
-            links:
-              - name: Github Issue
-                url: https://github.com/apache/solr-operator/issues/112
-              - name: Github PR
-                url: https://github.com/apache/solr-operator/pull/276
-          - kind: changed
-            description: Default Solr Version upgraded to 8.9, does not affect existing clouds
-            links:
-              - name: Github Issue
-                url: https://github.com/apache/solr-operator/issues/285
-              - name: Github PR
-                url: https://github.com/apache/solr-operator/pull/287
-          - kind: added
-            description: Ability to create serviceAccount for SolrCloud deployment through Helm chart.
-            links:
-              - name: Github Issue
-                url: https://github.com/apache/solr-operator/issues/264
-              - name: Github PR
-                url: https://github.com/apache/solr-operator/pull/283
-        artifacthub.io/containsSecurityUpdates: "false"
-        artifacthub.io/images: |
-          - name: solr
-            image: solr:8.9
-            whitelisted: true
-        artifacthub.io/links: |
-          - name: "Solr Source"
-            url: https://github.com/apache/solr
-          - name: "Helm Chart Source"
-            url: https://github.com/apache/solr-operator
-          - name: "Solr Documentation"
-            url: https://solr.apache.org/guide/
-          - name: "Solr on Kube Tutorials"
-            url: https://solr.apache.org/operator/resources#tutorials
-        artifacthub.io/operator: "false"
-        artifacthub.io/prerelease: "false"
-        artifacthub.io/recommendations: |
-          - url: https://artifacthub.io/packages/helm/apache-solr/solr-operator
-        artifacthub.io/signKey: |
-          fingerprint: 50E3EE1C91C7E0CB4DFB007B369424FC98F3F6EC
-          url: https://dist.apache.org/repos/dist/release/solr/KEYS
-      apiVersion: v2
-      appVersion: 8.9.0
-      created: "2021-09-13T12:49:36.724795-04:00"
-      description: A SolrCloud cluser running on Kubernetes via the Solr Operator
-      digest: b004e8abcc6d30139d0d59b966a8c47d6cae42585c6d735c49ce7eaed76590c3
-      home: https://solr.apache.org
-      icon: https://solr.apache.org/theme/images/identity/Solr_Logo_on_white.png
-      keywords:
-        - solr
-        - apache
-        - search
-        - lucene
-      kubeVersion: '>= 1.16.0-0'
-      maintainers:
-        - email: dev@solr.apache.org
-          name: Solr Dev Community
-        - email: houston@apache.org
-          name: Houston Putman
-      name: solr
-      sources:
-        - https://github.com/apache/solr
-        - https://github.com/apache/solr-operator
-      urls:
-        - solr-0.4.0.tgz
-      version: 0.4.0
+  - annotations:
+      artifacthub.io/changes: |
+        - kind: changed
+          description: The minimum supported version for Kubernetes is now v1.19.
+          links:
+            - name: Github Issue
+              url: https://github.com/apache/solr-operator/issues/277
+            - name: Github PR
+              url: https://github.com/apache/solr-operator/pull/321
+        - kind: deprecated
+          description: The legacy backup options (dataStorage.backupRestoreOptions) have been deprecated. Please use backupRepositories instead.
+          links:
+            - name: Github Issue
+              url: https://github.com/apache/solr-operator/issues/301
+            - name: Github PR
+              url: https://github.com/apache/solr-operator/pull/302
+            - name: Backup Documentation
+              url: https://apache.github.io/solr-operator/docs/solr-backup/
+      artifacthub.io/containsSecurityUpdates: "false"
+      artifacthub.io/images: |
+        - name: solr
+          image: solr:8.9
+          whitelisted: true
+      artifacthub.io/links: |
+        - name: "Solr Source"
+          url: https://github.com/apache/solr
+        - name: "Helm Chart Source"
+          url: https://github.com/apache/solr-operator
+        - name: "Solr Documentation"
+          url: https://solr.apache.org/guide/
+        - name: "Solr on Kube Tutorials"
+          url: https://solr.apache.org/operator/resources#tutorials
+      artifacthub.io/operator: "false"
+      artifacthub.io/prerelease: "false"
+      artifacthub.io/recommendations: |
+        - url: https://artifacthub.io/packages/helm/apache-solr/solr-operator
+      artifacthub.io/signKey: |
+        fingerprint: 50E3EE1C91C7E0CB4DFB007B369424FC98F3F6EC
+        url: https://dist.apache.org/repos/dist/release/solr/KEYS
+    apiVersion: v2
+    appVersion: 8.9.0
+    created: "2021-11-16T17:45:58.964581-05:00"
+    description: A SolrCloud cluser running on Kubernetes via the Solr Operator
+    digest: 821bf7f056ba46c44959e0e4024c539ae1cfd4a38cb55b80d113f785b2d87d9b
+    home: https://solr.apache.org
+    icon: https://solr.apache.org/theme/images/identity/Solr_Logo_on_white.png
+    keywords:
+    - solr
+    - apache
+    - search
+    - lucene
+    kubeVersion: '>= 1.19.0-0'
+    maintainers:
+    - email: dev@solr.apache.org
+      name: Solr Dev Community
+    - email: houston@apache.org
+      name: Houston Putman
+    name: solr
+    sources:
+    - https://github.com/apache/solr
+    - https://github.com/apache/solr-operator
+    urls:
+    - https://www.apache.org/dyn/closer.lua/solr/solr-operator/v0.5.0/helm-charts/solr-0.5.0.tgz?action=download&filename=solr/solr-operator/v0.5.0/helm-charts/solr-0.5.0.tgz
+    version: 0.5.0
+  - annotations:
+      artifacthub.io/changes: |
+        - kind: added
+          description: Official Solr Helm chart created. Works with the Solr Operator.
+          links:
+            - name: Github Issue
+              url: https://github.com/apache/solr-operator/issues/112
+            - name: Github PR
+              url: https://github.com/apache/solr-operator/pull/276
+        - kind: changed
+          description: Default Solr Version upgraded to 8.9, does not affect existing clouds
+          links:
+            - name: Github Issue
+              url: https://github.com/apache/solr-operator/issues/285
+            - name: Github PR
+              url: https://github.com/apache/solr-operator/pull/287
+        - kind: added
+          description: Ability to create serviceAccount for SolrCloud deployment through Helm chart.
+          links:
+            - name: Github Issue
+              url: https://github.com/apache/solr-operator/issues/264
+            - name: Github PR
+              url: https://github.com/apache/solr-operator/pull/283
+      artifacthub.io/containsSecurityUpdates: "false"
+      artifacthub.io/images: |
+        - name: solr
+          image: solr:8.9
+          whitelisted: true
+      artifacthub.io/links: |
+        - name: "Solr Source"
+          url: https://github.com/apache/solr
+        - name: "Helm Chart Source"
+          url: https://github.com/apache/solr-operator
+        - name: "Solr Documentation"
+          url: https://solr.apache.org/guide/
+        - name: "Solr on Kube Tutorials"
+          url: https://solr.apache.org/operator/resources#tutorials
+      artifacthub.io/operator: "false"
+      artifacthub.io/prerelease: "false"
+      artifacthub.io/recommendations: |
+        - url: https://artifacthub.io/packages/helm/apache-solr/solr-operator
+      artifacthub.io/signKey: |
+        fingerprint: 50E3EE1C91C7E0CB4DFB007B369424FC98F3F6EC
+        url: https://dist.apache.org/repos/dist/release/solr/KEYS
+    apiVersion: v2
+    appVersion: 8.9.0
+    created: "2021-09-13T12:49:36.724795-04:00"
+    description: A SolrCloud cluser running on Kubernetes via the Solr Operator
+    digest: b004e8abcc6d30139d0d59b966a8c47d6cae42585c6d735c49ce7eaed76590c3
+    home: https://solr.apache.org
+    icon: https://solr.apache.org/theme/images/identity/Solr_Logo_on_white.png
+    keywords:
+    - solr
+    - apache
+    - search
+    - lucene
+    kubeVersion: '>= 1.16.0-0'
+    maintainers:
+    - email: dev@solr.apache.org
+      name: Solr Dev Community
+    - email: houston@apache.org
+      name: Houston Putman
+    name: solr
+    sources:
+    - https://github.com/apache/solr
+    - https://github.com/apache/solr-operator
+    urls:
+    - https://www.apache.org/dyn/closer.lua/solr/solr-operator/v0.4.0/helm-charts/solr-0.4.0.tgz?action=download&filename=solr/solr-operator/v0.4.0/helm-charts/solr-0.4.0.tgz
+    version: 0.4.0
   solr-operator:
-    - annotations:
-        artifacthub.io/changes: |
-          - kind: changed
-            description: The minimum supported version for Kubernetes is now v1.19. The Solr Operator is no longer using deprecated APIs, such as networking.k8s.io/v1beta1 for Ingresses.
-            links:
-              - name: Github Issue
-                url: https://github.com/apache/solr-operator/issues/277
-              - name: Github PR
-                url: https://github.com/apache/solr-operator/pull/321
-          - kind: changed
-            description: The Solr Operator has upgraded its Kubebuilder dependency to v3.
-            links:
-              - name: Bug Report Issue
-                url: https://github.com/apache/solr-operator/issues/320
-              - name: Github PR
-                url: https://github.com/apache/solr-operator/pull/321
-          - kind: fixed
-            description: The SolrPrometheusExporter controller now watches for changes in referenced Solr Clouds, so the referenced ZKConnectionString is updated if it changes within the SolrCloud status.
-            links:
-              - name: Bug Report Issue
-                url: https://github.com/apache/solr-operator/issues/325
-              - name: Github PR (Large and almost entirely unrelated)
-                url: https://github.com/apache/solr-operator/pull/321
-          - kind: deprecated
-            description: The legacy backup options (SolrCloud.spec.dataStorage.backupRestoreOptions) have been deprecated. Please use SolrCloud.spec.backupRepositories instead.
-            links:
-              - name: Github Issue
-                url: https://github.com/apache/solr-operator/issues/301
-              - name: Github PR
-                url: https://github.com/apache/solr-operator/pull/302
-              - name: Backup Documentation
-                url: https://apache.github.io/solr-operator/docs/solr-backup/
-          - kind: added
-            description: Introduced the ability to use GCS Backup Repositories with SolrCloud and SolrBackup.
-            links:
-              - name: Github Issue
-                url: https://github.com/apache/solr-operator/issues/301
-              - name: Github PR
-                url: https://github.com/apache/solr-operator/pull/302
-              - name: Backup Documentation
-                url: https://apache.github.io/solr-operator/docs/solr-backup#gcs-backup-repositories
-          - kind: added
-            description: Introduced the ability to use S3 Backup Repositories with SolrCloud and SolrBackup.
-            links:
-              - name: Github Issue
-                url: https://github.com/apache/solr-operator/issues/328
-              - name: Github PR
-                url: https://github.com/apache/solr-operator/pull/345
-              - name: Solr S3 Repository Documentation
-                url: https://solr.apache.org/guide/8_10/making-and-restoring-backups.html#s3backuprepository
-              - name: Backup Documentation
-                url: https://apache.github.io/solr-operator/docs/solr-backup#s3-backup-repositories
-          - kind: added
-            description: Customize the Lifecycle for Solr and PrometheusExporter containers
-            links:
-              - name: Github Issue
-                url: https://github.com/apache/solr-operator/issues/322
-              - name: Github PR
-                url: https://github.com/apache/solr-operator/pull/324
-          - kind: added
-            description: Add support for using Solr Modules (contrib) and additional libraries
-            links:
-              - name: Github Issue
-                url: https://github.com/apache/solr-operator/issues/329
-              - name: Github PR
-                url: https://github.com/apache/solr-operator/pull/332
-              - name: Solr Modules
-                url: https://github.com/apache/solr/tree/main/solr/contrib
-          - kind: added
-            description: SolrBackups can now have a custom location specified to store the backup
-            links:
-              - name: Github PR
-                url: https://github.com/apache/solr-operator/pull/345
-          - kind: fixed
-            description: Fix for managed restarts across connected SolrCloud resources.
-            links:
-              - name: Github Issue
-                url: https://github.com/apache/solr-operator/issues/348
-              - name: Github PR
-                url: https://github.com/apache/solr-operator/pull/349
-          - kind: added
-            description: Ability to use topologySpreadConstraints for SolrCloud and SolrPrometheusExporter
-            links:
-              - name: Github Issue
-                url: https://github.com/apache/solr-operator/issues/53
-              - name: Github PR
-                url: https://github.com/apache/solr-operator/pull/350
-              - name: Topology Spread Constraints Documentation
-                url: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/
-          - kind: added
-            description: Ability to bootstrap security configuration from a security.json in a user-supplied secret
-            links:
-              - name: Github Issue
-                url: https://github.com/apache/solr-operator/issues/355
-              - name: Github PR
-                url: https://github.com/apache/solr-operator/pull/356
-          - kind: added
-            description: Export default Solr Operator metrics, and enable when using the Helm chart
-            links:
-              - name: Github Issue
-                url: https://github.com/apache/solr-operator/issues/307
-              - name: Github PR
-                url: https://github.com/apache/solr-operator/pull/360
-          - kind: added
-            description: Ability to set the IngressClassName for v1 Ingress resources.
-            links:
-              - name: Github Issue (Ingress v1)
-                url: https://github.com/apache/solr-operator/issues/277
-              - name: Github PR
-                url: https://github.com/apache/solr-operator/pull/363
-          - kind: removed
-            description: Removed "persistence" option for SolrBackups. Instead please use the S3 or GCP Backup Repositories (Solr 8.9+)
-            links:
-              - name: Github Issue
-                url: https://github.com/apache/solr-operator/issues/347
-              - name: Github PR
-                url: https://github.com/apache/solr-operator/pull/357
-          - kind: added
-            description: Support for more Zookeeper Pod customization options
-            links:
-              - name: Github Issue
-                url: https://github.com/apache/solr-operator/issues/352
-              - name: Github PR
-                url: https://github.com/apache/solr-operator/pull/361
-          - kind: added
-            description: Separate SolrCloud backup ready status by backup repository
-            links:
-              - name: Github Issue
-                url: https://github.com/apache/solr-operator/issues/326
-              - name: Github PR
-                url: https://github.com/apache/solr-operator/pull/358
-          - kind: added
-            description: Scheduled/Recurring SolrBackup support
-            links:
-              - name: Github Issue
-                url: https://github.com/apache/solr-operator/issues/303
-              - name: Github PR
-                url: https://github.com/apache/solr-operator/pull/359
-              - name: SolrBackup Documentation
-                url: https://apache.github.io/solr-operator/docs/solr-backup#recurring-backups
-          - kind: changed
-            description: Solr Operator Leader Election enabled by default
-            links:
-              - name: Github Issue
-                url: https://github.com/apache/solr-operator/issues/366
-              - name: Github PR
-                url: https://github.com/apache/solr-operator/pull/367
-        artifacthub.io/containsSecurityUpdates: "false"
-        artifacthub.io/crds: |
-          - kind: SolrCloud
-            version: v1beta1
-            name: solrcloud.solr.apache.org
-            displayName: Solr Cloud
-            description: A distributed Solr Cloud cluster
-          - kind: SolrPrometheusExporter
-            version: v1beta1
-            name: solrprometheusexporter.solr.apache.org
-            displayName: Solr Prometheus Exporter
-            description: A Prometheus metrics exporter for Solr
-          - kind: SolrBackup
-            version: v1beta1
-            name: solrbackup.solr.apache.org
-            displayName: Solr Backup
-            description: A backup mechanism for Solr
-        artifacthub.io/crdsExamples: |
-          - apiVersion: solr.apache.org/v1beta1
-            kind: SolrCloud
-            metadata:
-              name: example
-            spec:
-              dataStorage:
-                persistent:
-                  reclaimPolicy: Delete
-                  pvcTemplate:
-                    spec:
-                      resources:
-                        requests:
-                          storage: "20Gi"
-              replicas: 3
-              solrImage:
-                tag: 8.7.0
-              solrJavaMem: "-Xms4g -Xmx4g"
-              customSolrKubeOptions:
-                podOptions:
-                  resources:
-                    requests:
-                      memory: "6G"
-              zookeeperRef:
-                provided:
-                  replicas: 3
-              solrOpts: "-Dsolr.autoSoftCommit.maxTime=10000"
-              solrGCTune: "-XX:SurvivorRatio=4 -XX:TargetSurvivorRatio=90 -XX:MaxTenuringThreshold=8"
-              backupRepositories:
-                - name: default-gcs
-                  gcs:
-                    bucket: solr-gcs-backups
-                    gcsCredentialSecret: # Required
-                      name: gcs-credentials
-                      key: "service-account-key.json"
-                    baseLocation: "/solrcloud/backups"
-                - name: default-s3
-                  s3:
-                    region: us-west-2
-                    bucket: solr-s3-backups
-                    credentials:
-                      accessKeyIdSecret: # Optional
-                        name: aws-secrets
-                        key: access-key-id
-                      secretAccessKeySecret: # Optional
-                        name: aws-secrets
-                        key: secret-access-key
-          - apiVersion: solr.apache.org/v1beta1
-            kind: SolrPrometheusExporter
-            metadata:
-              name: example
-            spec:
-              solrReference:
-                cloud:
-                  name: "example"
-              numThreads: 4
-              image:
-                tag: 8.7.0
-          - apiVersion: solr.apache.org/v1beta1
-            kind: SolrPrometheusExporter
-            metadata:
-              name: example
-            spec:
-              solrReference:
-                cloud:
-                  name: "example"
-              numThreads: 4
-              image:
-                tag: 8.7.0
-          - apiVersion: solr.apache.org/v1beta1
-            kind: SolrBackup
-            metadata:
-              name: example
-            spec:
-              repositoryName: solr-gcs-backups
-              solrCloud: example
-              collections:
-                - techproducts
-                - books
-              location: "/this/location"
-        artifacthub.io/images: |
-          - name: solr-operator
-            image: apache/solr-operator:v0.5.0
-        artifacthub.io/links: |
-          - name: "Tutorials"
-            url: https://solr.apache.org/operator/resources#tutorials
-        artifacthub.io/operator: "true"
-        artifacthub.io/operatorCapabilities: Full Lifecycle
-        artifacthub.io/prerelease: "false"
-        artifacthub.io/recommendations: |
-          - url: https://artifacthub.io/packages/helm/apache-solr/solr
-        artifacthub.io/signKey: |
-          fingerprint: 50E3EE1C91C7E0CB4DFB007B369424FC98F3F6EC
-          url: https://dist.apache.org/repos/dist/release/solr/KEYS
-      apiVersion: v2
-      appVersion: v0.5.0
-      created: "2021-11-16T17:45:58.973569-05:00"
-      dependencies:
-        - condition: zookeeper-operator.install
-          name: zookeeper-operator
-          repository: https://charts.pravega.io
-          version: 0.2.12
-      description: The Solr Operator enables easy management of Solr resources within
-        Kubernetes.
-      digest: 5ceeea0ba48f280cf25a92d63fe5d06e298640e683f4d8fea647fabc045d9a2c
-      home: https://solr.apache.org/operator
-      icon: https://solr.apache.org/theme/images/identity/Solr_Logo_on_white.png
-      keywords:
-        - solr
-        - apache
-        - search
-        - lucene
-        - operator
-      kubeVersion: '>= 1.19.0-0'
-      maintainers:
-        - email: dev@solr.apache.org
-          name: Solr Dev Community
-        - email: houston@apache.org
-          name: Houston Putman
-      name: solr-operator
-      sources:
-        - https://github.com/apache/solr-operator
-      urls:
-        - solr-operator-0.5.0.tgz
-      version: 0.5.0
-    - annotations:
-        artifacthub.io/changes: |
-          - kind: changed
-            description: Zookeeper Operator supported version changed to v0.2.12
-            links:
-              - name: Github Issue
-                url: https://github.com/apache/solr-operator/issues/271
-              - name: Github PR
-                url: https://github.com/apache/solr-operator/pull/304
-              - name: Zookeeper Operator Release Notes
-                url: https://github.com/pravega/zookeeper-operator/releases/tag/v0.2.12
-          - kind: added
-            description: Ability to schedule automatic restarts for SolrClouds
-            links:
-              - name: Github Issue
-                url: https://github.com/apache/solr-operator/issues/281
-              - name: Github PR
-                url: https://github.com/apache/solr-operator/pull/279
-          - kind: added
-            description: Ability to use HostPath volumes for ephemeral Solr storage
-            links:
-              - name: Github Issue
-                url: https://github.com/apache/solr-operator/issues/266
-              - name: Github PR
-                url: https://github.com/apache/solr-operator/pull/265
-          - kind: removed
-            description: "Removed deprecated Solr Operator Helm chart option `useZkOperator`, use `zookeeper-operator.use` instead"
-            links:
-              - name: Github Issue
-                url: https://github.com/apache/solr-operator/issues/286
-              - name: Github PR
-                url: https://github.com/apache/solr-operator/pull/288
-              - name: Deprecating Github PR
-                url: https://github.com/apache/solr-operator/pull/231
-          - kind: changed
-            description: Default Solr Version upgraded to 8.9, does not affect existing clouds
-            links:
-              - name: Github Issue
-                url: https://github.com/apache/solr-operator/issues/285
-              - name: Github PR
-                url: https://github.com/apache/solr-operator/pull/287
-          - kind: added
-            description: Customize serviceAccountName for SolrCloud and SolrPrometheusExporter
-            links:
-              - name: Github Issue
-                url: https://github.com/apache/solr-operator/issues/264
-              - name: Github PR
-                url: https://github.com/apache/solr-operator/pull/283
-          - kind: added
-            description: Introduced ephemeral option for Zookeeper storage
-            links:
-              - name: Github Issue
-                url: https://github.com/apache/solr-operator/issues/259
-              - name: Github PR
-                url: https://github.com/apache/solr-operator/pull/284
-          - kind: security
-            description: Changed Solr Operator base Docker image to reduce vulnerabilities.
-            links:
-              - name: Github Issue
-                url: https://github.com/apache/solr-operator/issues/294
-              - name: Github PR
-                url: https://github.com/apache/solr-operator/pull/295
-          - kind: added
-            description: Ability to customize probes for PrometheusExporter
-            links:
-              - name: Github Issue
-                url: https://github.com/apache/solr-operator/issues/282
-              - name: Github PR
-                url: https://github.com/apache/solr-operator/pull/297
-          - kind: security
-            description: Remove users role from the all permission in the initial security.json
-            links:
-              - name: Github Issue
-                url: https://github.com/apache/solr-operator/issues/274
-              - name: Github PR
-                url: https://github.com/apache/solr-operator/pull/299
-          - kind: fixed
-            description: Grant access to the /admin/zookeeper/status path to the k8s role in the initial security.json
-            links:
-              - name: Github Issue
-                url: https://github.com/apache/solr-operator/issues/289
-              - name: Github PR
-                url: https://github.com/apache/solr-operator/pull/299
-          - kind: security
-            description: Add a mountedServerTLSDir config option to support a unique certificate per pod mounted dynamically by an external agent or CSI driver
-            links:
-              - name: Github Issue
-                url: https://github.com/apache/solr-operator/issues/291
-              - name: Github PR
-                url: https://github.com/apache/solr-operator/pull/292
-          - kind: added
-            description: Ability to terminate TLS at Ingress for SolrCloud.
-            links:
-              - name: Github Issue
-                url: https://github.com/apache/solr-operator/issues/268
-              - name: Github PR
-                url: https://github.com/apache/solr-operator/pull/293
-          - kind: added
-            description: Ability to schedule automatic restarts for SolrPrometheusExporters
-            links:
-              - name: Github Issue
-                url: https://github.com/apache/solr-operator/issues/310
-              - name: Github PR
-                url: https://github.com/apache/solr-operator/pull/313
-          - kind: added
-            description: Ability to specify ZK Config properties for provided Zookeeper Clusters.
-            links:
-              - name: Github Issue
-                url: https://github.com/apache/solr-operator/issues/290
-              - name: Github PR
-                url: https://github.com/apache/solr-operator/pull/311
-          - kind: added
-            description: Option to watch for updates to the mTLS client certificate used by the operator to call Solr pods.
-            links:
-              - name: Github Issue
-                url: https://github.com/apache/solr-operator/issues/317
-              - name: Github PR
-                url: https://github.com/apache/solr-operator/pull/318
-          - kind: added
-            description: Configuration options to support an additional client TLS cert in addition to the server certificate
-            links:
-              - name: Github Issue
-                url: https://github.com/apache/solr-operator/issues/300
-              - name: Github PR
-                url: https://github.com/apache/solr-operator/pull/312
-        artifacthub.io/crds: |
-          - kind: SolrCloud
-            version: v1beta1
-            name: solrcloud.solr.apache.org
-            displayName: Solr Cloud
-            description: A distributed Solr Cloud cluster
-          - kind: SolrPrometheusExporter
-            version: v1beta1
-            name: solrprometheusexporter.solr.apache.org
-            displayName: Solr Prometheus Exporter
-            description: A Prometheus metrics exporter for Solr
-          - kind: SolrBackup
-            version: v1beta1
-            name: solrbackup.solr.apache.org
-            displayName: Solr Backup
-            description: A backup mechanism for Solr
-        artifacthub.io/crdsExamples: |
-          - apiVersion: solr.apache.org/v1beta1
-            kind: SolrCloud
-            metadata:
-              name: example
-            spec:
-              dataStorage:
-                persistent:
-                  reclaimPolicy: Delete
-                  pvcTemplate:
-                    spec:
-                      resources:
-                        requests:
-                          storage: "20Gi"
-              replicas: 3
-              solrImage:
-                tag: 8.7.0
-              solrJavaMem: "-Xms4g -Xmx4g"
-              customSolrKubeOptions:
-                podOptions:
-                  resources:
-                    requests:
-                      memory: "6G"
-              zookeeperRef:
-                provided:
-                  replicas: 3
-              solrOpts: "-Dsolr.autoSoftCommit.maxTime=10000"
-              solrGCTune: "-XX:SurvivorRatio=4 -XX:TargetSurvivorRatio=90 -XX:MaxTenuringThreshold=8"
-          - apiVersion: solr.apache.org/v1beta1
-            kind: SolrPrometheusExporter
-            metadata:
-              name: example
-            spec:
-              solrReference:
-                cloud:
-                  name: "example"
-              numThreads: 4
-              image:
-                tag: 8.7.0
-        artifacthub.io/images: |
-          - name: solr-operator
-            image: apache/solr-operator:v0.4.0
-        artifacthub.io/links: |
-          - name: "Tutorials"
-            url: https://solr.apache.org/operator/resources#tutorials
-        artifacthub.io/operator: "true"
-        artifacthub.io/operatorCapabilities: Seamless Upgrades
-        artifacthub.io/prerelease: "false"
-        artifacthub.io/recommendations: |
-          - url: https://artifacthub.io/packages/helm/apache-solr/solr
-        artifacthub.io/signKey: |
-          fingerprint: 50E3EE1C91C7E0CB4DFB007B369424FC98F3F6EC
-          url: https://dist.apache.org/repos/dist/release/solr/KEYS
-      apiVersion: v2
-      appVersion: v0.4.0
-      created: "2021-09-13T09:09:04.673575-04:00"
-      dependencies:
-        - condition: zookeeper-operator.install
-          name: zookeeper-operator
-          repository: https://charts.pravega.io
-          version: 0.2.12
-      description: The Solr Operator enables easy management of Solr resources within
-        Kubernetes.
-      digest: 3d0a5236a0f578b34bfa8aa5de066cc7dedcdbb153ff325d8b5d815c53cb4cbf
-      home: https://solr.apache.org/operator
-      icon: https://solr.apache.org/theme/images/identity/Solr_Logo_on_white.png
-      keywords:
-        - solr
-        - apache
-        - search
-        - lucene
-        - operator
-      kubeVersion: '>= 1.16.0-0'
-      maintainers:
-        - email: dev@solr.apache.org
-          name: Solr Dev Community
-        - email: houston@apache.org
-          name: Houston Putman
-      name: solr-operator
-      sources:
-        - https://github.com/apache/solr-operator
-      urls:
-        - solr-operator-0.4.0.tgz
-      version: 0.4.0
-    - annotations:
-        artifacthub.io/changes: |
-          - The Solr Operator is now an Apache project managed by the Apache Solr PMC
-          - The Solr CRDs now use the solr.apache.org API group instead of solr.bloomberg.com
-          - The Solr Operator now fully supports running Solr in a secure and locked down way
-          - Basic Auth support is now built in when requested in the SolrCloud CRD
-          - Solr can be run with TLS, with optional mTLS if provided to the operator
-          - More helm chart options are provided to customize running the Solr Operator
-          - The Zookeeper Operator is now up-to-date with the most recent release, v0.2.9
-          - The Zookeeper Operator can now be installed as a helm-chart dependency with the Solr Operator
-          - Users can now provide custom Solr log4j.xml and Prometheus Exporter config xml configMaps
-          - Fix bug in custom probes for Solr pods
-          - Solr pod shutdown is more graceful, has better coordination between Kubernetes and Solr
-          - SolrCloud can now be used with the Kubernetes HPA to autoscale Solr Cloud pods
-        artifacthub.io/crds: |
-          - kind: SolrCloud
-            version: v1beta1
-            name: solrcloud.solr.apache.org
-            displayName: Solr Cloud
-            description: A distributed Solr Cloud cluster
-          - kind: SolrPrometheusExporter
-            version: v1beta1
-            name: solrprometheusexporter.solr.apache.org
-            displayName: Solr Prometheus Exporter
-            description: A Prometheus metrics exporter for Solr
-          - kind: SolrBackup
-            version: v1beta1
-            name: solrbackup.solr.apache.org
-            displayName: Solr Backup
-            description: A backup mechanism for Solr
-        artifacthub.io/crdsExamples: |
-          - apiVersion: solr.apache.org/v1beta1
-            kind: SolrCloud
-            metadata:
-              name: example
-            spec:
-              dataStorage:
-                persistent:
-                  reclaimPolicy: Delete
-                  pvcTemplate:
-                    spec:
-                      resources:
-                        requests:
-                          storage: "20Gi"
-              replicas: 3
-              solrImage:
-                tag: 8.7.0
-              solrJavaMem: "-Xms4g -Xmx4g"
-              customSolrKubeOptions:
-                podOptions:
-                  resources:
-                    requests:
-                      memory: "6G"
-              zookeeperRef:
-                provided:
-                  replicas: 3
-              solrOpts: "-Dsolr.autoSoftCommit.maxTime=10000"
-              solrGCTune: "-XX:SurvivorRatio=4 -XX:TargetSurvivorRatio=90 -XX:MaxTenuringThreshold=8"
-          - apiVersion: solr.apache.org/v1beta1
-            kind: SolrPrometheusExporter
-            metadata:
-              name: example
-            spec:
-              solrReference:
-                cloud:
-                  name: "example"
-              numThreads: 4
-              image:
-                tag: 8.7.0
-        artifacthub.io/images: |
-          - name: solr-operator
-            image: apache/solr-operator:v0.3.0
-        artifacthub.io/operator: "true"
-        artifacthub.io/operatorCapabilities: Seamless Upgrades
-        artifacthub.io/prerelease: "false"
-      apiVersion: v2
-      appVersion: v0.3.0
-      created: "2021-04-29T13:39:05.588431-05:00"
-      dependencies:
-        - condition: zookeeper-operator.install
-          name: zookeeper-operator
-          repository: https://charts.pravega.io
-          version: 0.2.9
-      description: The Solr Operator enables easy management of Solr resources within
-        Kubernetes.
-      digest: b62a5c33189789a07c59e59c5d4f3072c8c7367c91b8e977e4eb68af9bb16b28
-      home: https://github.com/apache/solr-operator
-      icon: https://solr.apache.org/theme/images/identity/Solr_Logo_on_white.png
-      keywords:
-        - solr
-        - apache
-        - search
-        - lucene
-        - operator
-      kubeVersion: '>= 1.16.0-0'
-      maintainers:
-        - email: dev@solr.apache.org
-          name: Solr Dev Community
-        - email: houston@apache.org
-          name: Houston Putman
-      name: solr-operator
-      sources:
-        - https://github.com/apache/solr-operator
-      urls:
-        - solr-operator-0.3.0.tgz
-      version: 0.3.0
-    - annotations:
-        artifacthub.io/changes: |-
-          - This will be the last release of the Bloomberg Solr Operator.
-            All new versions will be release from the Apache organization.
-          - Fixing upgrade issue with new Status fields
-        artifacthub.io/crds: |
-          - kind: SolrCloud
-            version: v1beta1
-            name: solrcloud.solr.bloomberg.com
-            displayName: Solr Cloud
-            description: A distributed Solr Cloud cluster
-          - kind: SolrPrometheusExporter
-            version: v1beta1
-            name: solrprometheusexporter.solr.bloomberg.com
-            displayName: Solr Prometheus Exporter
-            description: A Prometheus metrics exporter for Solr
-          - kind: SolrBackup
-            version: v1beta1
-            name: solrbackup.solr.bloomberg.com
-            displayName: Solr Backup
-            description: A backup mechanism for Solr
-        artifacthub.io/crdsExamples: |
-          - apiVersion: solr.bloomberg.com/v1beta1
-            kind: SolrCloud
-            metadata:
-              name: example
-            spec:
-              dataStorage:
-                persistent:
-                  reclaimPolicy: Delete
-                  pvcTemplate:
-                    spec:
-                      resources:
-                        requests:
-                          storage: "20Gi"
-              replicas: 3
-              solrImage:
-                tag: 8.7.0
-              solrJavaMem: "-Xms4g -Xmx4g"
-              customSolrKubeOptions:
-                podOptions:
-                  resources:
-                    requests:
-                      memory: "6G"
-              zookeeperRef:
-                provided:
-                  replicas: 3
-              solrOpts: "-Dsolr.autoSoftCommit.maxTime=10000"
-              solrGCTune: "-XX:SurvivorRatio=4 -XX:TargetSurvivorRatio=90 -XX:MaxTenuringThreshold=8"
-          - apiVersion: solr.bloomberg.com/v1beta1
-            kind: SolrPrometheusExporter
-            metadata:
-              name: example
-            spec:
-              solrReference:
-                cloud:
-                  name: "example"
-              numThreads: 4
-              image:
-                tag: 8.7.0
-        artifacthub.io/images: |
-          - name: solr-operator
-            image: bloomberg/solr-operator:v0.2.8
-        artifacthub.io/operator: "true"
-        artifacthub.io/operatorCapabilities: Seamless Upgrades
-        artifacthub.io/prerelease: "false"
-      apiVersion: v1
-      appVersion: v0.2.8
-      created: "2021-01-11T15:21:23.033109-05:00"
-      description: The Solr Operator enables easy management of Solr resources within
-        Kubernetes.
-      digest: 27fcb78a7cf8e76cec6fb99b1aef02224fa25485425266f4e5be20f9b6d04801
-      home: https://github.com/apache/solr-operator
-      icon: https://solr.apache.org/theme/images/identity/Solr_Logo_on_white.png
-      keywords:
-        - solr
-        - apache
-        - search
-        - lucene
-        - operator
-      kubeVersion: '>= 1.16.0-0'
-      maintainers:
-        - email: dev@solr.apache.org
-          name: Solr Dev Community
-        - email: houston@apache.org
-          name: Houston Putman
-      name: solr-operator
-      sources:
-        - https://github.com/apache/solr-operator
-      urls:
-        - solr-operator-0.2.8.tgz
-      version: 0.2.8
-    - annotations:
-        artifacthub.io/changes: |
-          - |
-            Kubernetes 1.16+ is required for for this release of the Solr Operator.
-            Please continue using v0.2.6 until you are able to upgrade your Kubernetes cluster.
-          - Removed support for etcd/zetcd deployments.
-          - Deprecations (All deprecations will be removed in v0.3.0)
-          - |
-            The section for a Zookeeper cluster Spec "SolrCloud.spec.zookeeperRef.provided.zookeeper" has been DEPRECATED.
-            The same fields (except for the deprecated persistentVolumeClaimSpec option) are now available under "SolrCloud.spec.zookeeperRef.provided".
-          - Data Storage options have been expanded, and moved from their old locations.
-          - |
-            "SolrCloud.spec.dataPvcSpec" has been DEPRECATED.
-            Please instead use the following instead: "SolrCloud.spec.dataStorage.persistent.pvcTemplate.spec"
-          - |
-            "SolrCloud.spec.backupRestoreVolume" has been DEPRECATED.
-            Please instead use the following instead: "SolrCloud.spec.dataStorage.backupRestoreOptions.Volume"
-          - The SolrCloud and SolrPrometheusExporter services' portNames have changed to "solr-client" and "solr-metrics" from "ext-solr-client" and "ext-solr-metrics", respectivelyi.
-          - |
-            The default PodManagementPolicy for StatefulSets has been changed to Parallel from OrderedReady.
-            This change will not affect existing StatefulSets, as PodManagementPolicy cannot be updated.
-            In order to continue using OrderedReady on new SolrClouds, please use the following setting:
-            "SolrCloud.spec.customSolrKubeOptions.statefulSetOptions.podManagementPolicy"
-          - The location of backup-restore volume mounts in Solr containers has changed from "/var/solr/solr-backup-restore" to "/var/solr/data/backup-restore".
-          - Introduced a managed SolrCloud update strategy
-          - Added PriorityClassName in podOptions
-          - Added option to provide ZK ACLs
-          - Added dataStorage options for SolrCloud - PVC reclaim policy & Ephemeral Volume spec for non-persistent storage
-          - Ability to provide custom solr.xml for SolrCloud
-          - Ability to specify sidecar container and additional initContainers
-          - Gracefully shutdown Solr nodes using the Solr stop port
-          - Adding scope=Namespaced to all CRDs
-          - Move chroot creation logic to pod postStart and out of operator
-          - Change default SolrCloud podManagementPolicy to Parallel from OrderedReady
-          - ZKConnectionString now uses all ZK hosts with Provided ZK
-          - Fix service port name and status URL bugs
-          - Fix never-ending reconcile loop for ZKs
-          - Fix never-ending reconcile loop for ingresses in Kube 1.18+
-          - SolrBackup now works with Solr 8.6+
-          - Fixed an issue with volume permissions in the read-write-many volume for Backups
-          - Remove default imagePullPolicy for pods
-          - Upgraded CRD versions to v1, from v1beta1
-        artifacthub.io/crds: |
-          - kind: SolrCloud
-            version: v1beta1
-            name: solrcloud.solr.bloomberg.com
-            displayName: Solr Cloud
-            description: A distributed Solr Cloud cluster
-          - kind: SolrPrometheusExporter
-            version: v1beta1
-            name: solrprometheusexporter.solr.bloomberg.com
-            displayName: Solr Prometheus Exporter
-            description: A Prometheus metrics exporter for Solr
-          - kind: SolrBackup
-            version: v1beta1
-            name: solrbackup.solr.bloomberg.com
-            displayName: Solr Backup
-            description: A backup mechanism for Solr
-        artifacthub.io/crdsExamples: |
-          - apiVersion: solr.bloomberg.com/v1beta1
-            kind: SolrCloud
-            metadata:
-              name: example
-            spec:
-              dataStorage:
-                persistent:
-                  reclaimPolicy: Delete
-                  pvcTemplate:
-                    spec:
-                      resources:
-                        requests:
-                          storage: "20Gi"
-              replicas: 3
-              solrImage:
-                tag: 8.7.0
-              solrJavaMem: "-Xms4g -Xmx4g"
-              customSolrKubeOptions:
-                podOptions:
-                  resources:
-                    requests:
-                      memory: "6G"
-              zookeeperRef:
-                provided:
-                  replicas: 3
-              solrOpts: "-Dsolr.autoSoftCommit.maxTime=10000"
-              solrGCTune: "-XX:SurvivorRatio=4 -XX:TargetSurvivorRatio=90 -XX:MaxTenuringThreshold=8"
-          - apiVersion: solr.bloomberg.com/v1beta1
-            kind: SolrPrometheusExporter
-            metadata:
-              name: example
-            spec:
-              solrReference:
-                cloud:
-                  name: "example"
-              numThreads: 4
-              image:
-                tag: 8.7.0
-        artifacthub.io/images: |
-          - name: solr-operator
-            image: bloomberg/solr-operator:v0.2.7
-        artifacthub.io/operator: "true"
-        artifacthub.io/operatorCapabilities: Seamless Upgrades
-        artifacthub.io/prerelease: "false"
-      apiVersion: v1
-      appVersion: v0.2.7
-      created: "2021-01-11T15:21:23.033109-05:00"
-      description: The Solr Operator enables easy management of Solr resources within
-        Kubernetes.
-      digest: 93219551374cbda16be911aed57b86e208072304bafce023fabef39e35e677b1
-      home: https://github.com/apache/solr-operator
-      icon: https://solr.apache.org/theme/images/identity/Solr_Logo_on_white.png
-      keywords:
-        - solr
-        - apache
-        - search
-        - lucene
-        - operator
-      kubeVersion: '>= 1.13.0-0'
-      maintainers:
-        - email: dev@solr.apache.org
-          name: Solr Dev Community
-        - email: houston@apache.org
-          name: Houston Putman
-      name: solr-operator
-      sources:
-        - https://github.com/apache/solr-operator
-      urls:
-        - solr-operator-0.2.7.tgz
-      version: 0.2.7
-    - annotations:
-        artifacthub.io/changes: |
-          - Helm chart fixes and improvements
-          - Adding namespace functionality to operator and helm chart
-          - Adding custom addressability options to solrcloud
-          - Adding configurable liveness, readiness, startup checks
-          - Documentation improvements
-        artifacthub.io/crds: |
-          - kind: SolrCloud
-            version: v1beta1
-            name: solrcloud.solr.bloomberg.com
-            displayName: Solr Cloud
-            description: A distributed Solr Cloud cluster
-          - kind: SolrPrometheusExporter
-            version: v1beta1
-            name: solrprometheusexporter.solr.bloomberg.com
-            displayName: Solr Prometheus Exporter
-            description: A Prometheus metrics exporter for Solr
-          - kind: SolrBackup
-            version: v1beta1
-            name: solrbackup.solr.bloomberg.com
-            displayName: Solr Backup
-            description: A backup mechanism for Solr
-        artifacthub.io/crdsExamples: |
-          - apiVersion: solr.bloomberg.com/v1beta1
-            kind: SolrCloud
-            metadata:
-              name: example
-            spec:
-              replicas: 3
-              solrImage:
-                tag: 8.7.0
-              solrJavaMem: "-Xms4g -Xmx4g"
-              customSolrKubeOptions:
-                podOptions:
-                  resources:
-                    requests:
-                      memory: "6G"
-              solrOpts: "-Dsolr.autoSoftCommit.maxTime=10000"
-              solrGCTune: "-XX:SurvivorRatio=4 -XX:TargetSurvivorRatio=90 -XX:MaxTenuringThreshold=8"
-          - apiVersion: solr.bloomberg.com/v1beta1
-            kind: SolrPrometheusExporter
-            metadata:
-              name: example
-            spec:
-              solrReference:
-                cloud:
-                  name: "example"
-              numThreads: 4
-              image:
-                tag: 8.7.0
-        artifacthub.io/images: |
-          - name: solr-operator
-            image: bloomberg/solr-operator:v0.2.6
-        artifacthub.io/operator: "true"
-        artifacthub.io/operatorCapabilities: Basic Install
-        artifacthub.io/prerelease: "false"
-      apiVersion: v1
-      appVersion: v0.2.6
-      created: "2020-08-10T15:25:32.770735-04:00"
-      description: The Solr Operator enables easy management of Solr resources within
-        Kubernetes.
-      digest: 7c9650262509f1069c74738f4fd9dce4b3eec5198dedf8e710ccb54308756370
-      home: https://github.com/apache/solr-operator
-      icon: https://solr.apache.org/theme/images/identity/Solr_Logo_on_white.png
-      keywords:
-        - solr
-        - apache
-        - search
-        - lucene
-        - operator
-      kubeVersion: '>= 1.13.0-0'
-      maintainers:
-        - email: dev@solr.apache.org
-          name: Solr Dev Community
-        - email: houston@apache.org
-          name: Houston Putman
-        - email: bsankaranara@bloomberg.net
-          name: Balaji Sankaranarayanan
-      name: solr-operator
-      sources:
-        - https://github.com/apache/solr-operator
-      urls:
-        - solr-operator-0.2.6.tgz
-      version: 0.2.6
-generated: "2021-11-16T17:45:58.963106-05:00"
+  - annotations:
+      artifacthub.io/changes: |
+        - kind: changed
+          description: The minimum supported version for Kubernetes is now v1.19. The Solr Operator is no longer using deprecated APIs, such as networking.k8s.io/v1beta1 for Ingresses.
+          links:
+            - name: Github Issue
+              url: https://github.com/apache/solr-operator/issues/277
+            - name: Github PR
+              url: https://github.com/apache/solr-operator/pull/321
+        - kind: changed
+          description: The Solr Operator has upgraded its Kubebuilder dependency to v3.
+          links:
+            - name: Bug Report Issue
+              url: https://github.com/apache/solr-operator/issues/320
+            - name: Github PR
+              url: https://github.com/apache/solr-operator/pull/321
+        - kind: fixed
+          description: The SolrPrometheusExporter controller now watches for changes in referenced Solr Clouds, so the referenced ZKConnectionString is updated if it changes within the SolrCloud status.
+          links:
+            - name: Bug Report Issue
+              url: https://github.com/apache/solr-operator/issues/325
+            - name: Github PR (Large and almost entirely unrelated)
+              url: https://github.com/apache/solr-operator/pull/321
+        - kind: deprecated
+          description: The legacy backup options (SolrCloud.spec.dataStorage.backupRestoreOptions) have been deprecated. Please use SolrCloud.spec.backupRepositories instead.
+          links:
+            - name: Github Issue
+              url: https://github.com/apache/solr-operator/issues/301
+            - name: Github PR
+              url: https://github.com/apache/solr-operator/pull/302
+            - name: Backup Documentation
+              url: https://apache.github.io/solr-operator/docs/solr-backup/
+        - kind: added
+          description: Introduced the ability to use GCS Backup Repositories with SolrCloud and SolrBackup.
+          links:
+            - name: Github Issue
+              url: https://github.com/apache/solr-operator/issues/301
+            - name: Github PR
+              url: https://github.com/apache/solr-operator/pull/302
+            - name: Backup Documentation
+              url: https://apache.github.io/solr-operator/docs/solr-backup#gcs-backup-repositories
+        - kind: added
+          description: Introduced the ability to use S3 Backup Repositories with SolrCloud and SolrBackup.
+          links:
+            - name: Github Issue
+              url: https://github.com/apache/solr-operator/issues/328
+            - name: Github PR
+              url: https://github.com/apache/solr-operator/pull/345
+            - name: Solr S3 Repository Documentation
+              url: https://solr.apache.org/guide/8_10/making-and-restoring-backups.html#s3backuprepository
+            - name: Backup Documentation
+              url: https://apache.github.io/solr-operator/docs/solr-backup#s3-backup-repositories
+        - kind: added
+          description: Customize the Lifecycle for Solr and PrometheusExporter containers
+          links:
+            - name: Github Issue
+              url: https://github.com/apache/solr-operator/issues/322
+            - name: Github PR
+              url: https://github.com/apache/solr-operator/pull/324
+        - kind: added
+          description: Add support for using Solr Modules (contrib) and additional libraries
+          links:
+            - name: Github Issue
+              url: https://github.com/apache/solr-operator/issues/329
+            - name: Github PR
+              url: https://github.com/apache/solr-operator/pull/332
+            - name: Solr Modules
+              url: https://github.com/apache/solr/tree/main/solr/contrib
+        - kind: added
+          description: SolrBackups can now have a custom location specified to store the backup
+          links:
+            - name: Github PR
+              url: https://github.com/apache/solr-operator/pull/345
+        - kind: fixed
+          description: Fix for managed restarts across connected SolrCloud resources.
+          links:
+            - name: Github Issue
+              url: https://github.com/apache/solr-operator/issues/348
+            - name: Github PR
+              url: https://github.com/apache/solr-operator/pull/349
+        - kind: added
+          description: Ability to use topologySpreadConstraints for SolrCloud and SolrPrometheusExporter
+          links:
+            - name: Github Issue
+              url: https://github.com/apache/solr-operator/issues/53
+            - name: Github PR
+              url: https://github.com/apache/solr-operator/pull/350
+            - name: Topology Spread Constraints Documentation
+              url: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/
+        - kind: added
+          description: Ability to bootstrap security configuration from a security.json in a user-supplied secret
+          links:
+            - name: Github Issue
+              url: https://github.com/apache/solr-operator/issues/355
+            - name: Github PR
+              url: https://github.com/apache/solr-operator/pull/356
+        - kind: added
+          description: Export default Solr Operator metrics, and enable when using the Helm chart
+          links:
+            - name: Github Issue
+              url: https://github.com/apache/solr-operator/issues/307
+            - name: Github PR
+              url: https://github.com/apache/solr-operator/pull/360
+        - kind: added
+          description: Ability to set the IngressClassName for v1 Ingress resources.
+          links:
+            - name: Github Issue (Ingress v1)
+              url: https://github.com/apache/solr-operator/issues/277
+            - name: Github PR
+              url: https://github.com/apache/solr-operator/pull/363
+        - kind: removed
+          description: Removed "persistence" option for SolrBackups. Instead please use the S3 or GCP Backup Repositories (Solr 8.9+)
+          links:
+            - name: Github Issue
+              url: https://github.com/apache/solr-operator/issues/347
+            - name: Github PR
+              url: https://github.com/apache/solr-operator/pull/357
+        - kind: added
+          description: Support for more Zookeeper Pod customization options
+          links:
+            - name: Github Issue
+              url: https://github.com/apache/solr-operator/issues/352
+            - name: Github PR
+              url: https://github.com/apache/solr-operator/pull/361
+        - kind: added
+          description: Separate SolrCloud backup ready status by backup repository
+          links:
+            - name: Github Issue
+              url: https://github.com/apache/solr-operator/issues/326
+            - name: Github PR
+              url: https://github.com/apache/solr-operator/pull/358
+        - kind: added
+          description: Scheduled/Recurring SolrBackup support
+          links:
+            - name: Github Issue
+              url: https://github.com/apache/solr-operator/issues/303
+            - name: Github PR
+              url: https://github.com/apache/solr-operator/pull/359
+            - name: SolrBackup Documentation
+              url: https://apache.github.io/solr-operator/docs/solr-backup#recurring-backups
+        - kind: changed
+          description: Solr Operator Leader Election enabled by default
+          links:
+            - name: Github Issue
+              url: https://github.com/apache/solr-operator/issues/366
+            - name: Github PR
+              url: https://github.com/apache/solr-operator/pull/367
+      artifacthub.io/containsSecurityUpdates: "false"
+      artifacthub.io/crds: |
+        - kind: SolrCloud
+          version: v1beta1
+          name: solrcloud.solr.apache.org
+          displayName: Solr Cloud
+          description: A distributed Solr Cloud cluster
+        - kind: SolrPrometheusExporter
+          version: v1beta1
+          name: solrprometheusexporter.solr.apache.org
+          displayName: Solr Prometheus Exporter
+          description: A Prometheus metrics exporter for Solr
+        - kind: SolrBackup
+          version: v1beta1
+          name: solrbackup.solr.apache.org
+          displayName: Solr Backup
+          description: A backup mechanism for Solr
+      artifacthub.io/crdsExamples: |
+        - apiVersion: solr.apache.org/v1beta1
+          kind: SolrCloud
+          metadata:
+            name: example
+          spec:
+            dataStorage:
+              persistent:
+                reclaimPolicy: Delete
+                pvcTemplate:
+                  spec:
+                    resources:
+                      requests:
+                        storage: "20Gi"
+            replicas: 3
+            solrImage:
+              tag: 8.7.0
+            solrJavaMem: "-Xms4g -Xmx4g"
+            customSolrKubeOptions:
+              podOptions:
+                resources:
+                  requests:
+                    memory: "6G"
+            zookeeperRef:
+              provided:
+                replicas: 3
+            solrOpts: "-Dsolr.autoSoftCommit.maxTime=10000"
+            solrGCTune: "-XX:SurvivorRatio=4 -XX:TargetSurvivorRatio=90 -XX:MaxTenuringThreshold=8"
+            backupRepositories:
+              - name: default-gcs
+                gcs:
+                  bucket: solr-gcs-backups
+                  gcsCredentialSecret: # Required
+                    name: gcs-credentials
+                    key: "service-account-key.json"
+                  baseLocation: "/solrcloud/backups"
+              - name: default-s3
+                s3:
+                  region: us-west-2
+                  bucket: solr-s3-backups
+                  credentials:
+                    accessKeyIdSecret: # Optional
+                      name: aws-secrets
+                      key: access-key-id
+                    secretAccessKeySecret: # Optional
+                      name: aws-secrets
+                      key: secret-access-key
+        - apiVersion: solr.apache.org/v1beta1
+          kind: SolrPrometheusExporter
+          metadata:
+            name: example
+          spec:
+            solrReference:
+              cloud:
+                name: "example"
+            numThreads: 4
+            image:
+              tag: 8.7.0
+        - apiVersion: solr.apache.org/v1beta1
+          kind: SolrPrometheusExporter
+          metadata:
+            name: example
+          spec:
+            solrReference:
+              cloud:
+                name: "example"
+            numThreads: 4
+            image:
+              tag: 8.7.0
+        - apiVersion: solr.apache.org/v1beta1
+          kind: SolrBackup
+          metadata:
+            name: example
+          spec:
+            repositoryName: solr-gcs-backups
+            solrCloud: example
+            collections:
+              - techproducts
+              - books
+            location: "/this/location"
+      artifacthub.io/images: |
+        - name: solr-operator
+          image: apache/solr-operator:v0.5.0
+      artifacthub.io/links: |
+        - name: "Tutorials"
+          url: https://solr.apache.org/operator/resources#tutorials
+      artifacthub.io/operator: "true"
+      artifacthub.io/operatorCapabilities: Full Lifecycle
+      artifacthub.io/prerelease: "false"
+      artifacthub.io/recommendations: |
+        - url: https://artifacthub.io/packages/helm/apache-solr/solr
+      artifacthub.io/signKey: |
+        fingerprint: 50E3EE1C91C7E0CB4DFB007B369424FC98F3F6EC
+        url: https://dist.apache.org/repos/dist/release/solr/KEYS
+    apiVersion: v2
+    appVersion: v0.5.0
+    created: "2021-11-16T17:45:58.973569-05:00"
+    dependencies:
+    - condition: zookeeper-operator.install
+      name: zookeeper-operator
+      repository: https://charts.pravega.io
+      version: 0.2.12
+    description: The Solr Operator enables easy management of Solr resources within
+      Kubernetes.
+    digest: 5ceeea0ba48f280cf25a92d63fe5d06e298640e683f4d8fea647fabc045d9a2c
+    home: https://solr.apache.org/operator
+    icon: https://solr.apache.org/theme/images/identity/Solr_Logo_on_white.png
+    keywords:
+    - solr
+    - apache
+    - search
+    - lucene
+    - operator
+    kubeVersion: '>= 1.19.0-0'
+    maintainers:
+    - email: dev@solr.apache.org
+      name: Solr Dev Community
+    - email: houston@apache.org
+      name: Houston Putman
+    name: solr-operator
+    sources:
+    - https://github.com/apache/solr-operator
+    urls:
+    - https://www.apache.org/dyn/closer.lua/solr/solr-operator/v0.5.0/helm-charts/solr-operator-0.5.0.tgz?action=download&filename=solr/solr-operator/v0.5.0/helm-charts/solr-operator-0.5.0.tgz
+    version: 0.5.0
+  - annotations:
+      artifacthub.io/changes: |
+        - kind: changed
+          description: Zookeeper Operator supported version changed to v0.2.12
+          links:
+            - name: Github Issue
+              url: https://github.com/apache/solr-operator/issues/271
+            - name: Github PR
+              url: https://github.com/apache/solr-operator/pull/304
+            - name: Zookeeper Operator Release Notes
+              url: https://github.com/pravega/zookeeper-operator/releases/tag/v0.2.12
+        - kind: added
+          description: Ability to schedule automatic restarts for SolrClouds
+          links:
+            - name: Github Issue
+              url: https://github.com/apache/solr-operator/issues/281
+            - name: Github PR
+              url: https://github.com/apache/solr-operator/pull/279
+        - kind: added
+          description: Ability to use HostPath volumes for ephemeral Solr storage
+          links:
+            - name: Github Issue
+              url: https://github.com/apache/solr-operator/issues/266
+            - name: Github PR
+              url: https://github.com/apache/solr-operator/pull/265
+        - kind: removed
+          description: "Removed deprecated Solr Operator Helm chart option `useZkOperator`, use `zookeeper-operator.use` instead"
+          links:
+            - name: Github Issue
+              url: https://github.com/apache/solr-operator/issues/286
+            - name: Github PR
+              url: https://github.com/apache/solr-operator/pull/288
+            - name: Deprecating Github PR
+              url: https://github.com/apache/solr-operator/pull/231
+        - kind: changed
+          description: Default Solr Version upgraded to 8.9, does not affect existing clouds
+          links:
+            - name: Github Issue
+              url: https://github.com/apache/solr-operator/issues/285
+            - name: Github PR
+              url: https://github.com/apache/solr-operator/pull/287
+        - kind: added
+          description: Customize serviceAccountName for SolrCloud and SolrPrometheusExporter
+          links:
+            - name: Github Issue
+              url: https://github.com/apache/solr-operator/issues/264
+            - name: Github PR
+              url: https://github.com/apache/solr-operator/pull/283
+        - kind: added
+          description: Introduced ephemeral option for Zookeeper storage
+          links:
+            - name: Github Issue
+              url: https://github.com/apache/solr-operator/issues/259
+            - name: Github PR
+              url: https://github.com/apache/solr-operator/pull/284
+        - kind: security
+          description: Changed Solr Operator base Docker image to reduce vulnerabilities.
+          links:
+            - name: Github Issue
+              url: https://github.com/apache/solr-operator/issues/294
+            - name: Github PR
+              url: https://github.com/apache/solr-operator/pull/295
+        - kind: added
+          description: Ability to customize probes for PrometheusExporter
+          links:
+            - name: Github Issue
+              url: https://github.com/apache/solr-operator/issues/282
+            - name: Github PR
+              url: https://github.com/apache/solr-operator/pull/297
+        - kind: security
+          description: Remove users role from the all permission in the initial security.json
+          links:
+            - name: Github Issue
+              url: https://github.com/apache/solr-operator/issues/274
+            - name: Github PR
+              url: https://github.com/apache/solr-operator/pull/299
+        - kind: fixed
+          description: Grant access to the /admin/zookeeper/status path to the k8s role in the initial security.json
+          links:
+            - name: Github Issue
+              url: https://github.com/apache/solr-operator/issues/289
+            - name: Github PR
+              url: https://github.com/apache/solr-operator/pull/299
+        - kind: security
+          description: Add a mountedServerTLSDir config option to support a unique certificate per pod mounted dynamically by an external agent or CSI driver
+          links:
+            - name: Github Issue
+              url: https://github.com/apache/solr-operator/issues/291
+            - name: Github PR
+              url: https://github.com/apache/solr-operator/pull/292
+        - kind: added
+          description: Ability to terminate TLS at Ingress for SolrCloud.
+          links:
+            - name: Github Issue
+              url: https://github.com/apache/solr-operator/issues/268
+            - name: Github PR
+              url: https://github.com/apache/solr-operator/pull/293
+        - kind: added
+          description: Ability to schedule automatic restarts for SolrPrometheusExporters
+          links:
+            - name: Github Issue
+              url: https://github.com/apache/solr-operator/issues/310
+            - name: Github PR
+              url: https://github.com/apache/solr-operator/pull/313
+        - kind: added
+          description: Ability to specify ZK Config properties for provided Zookeeper Clusters.
+          links:
+            - name: Github Issue
+              url: https://github.com/apache/solr-operator/issues/290
+            - name: Github PR
+              url: https://github.com/apache/solr-operator/pull/311
+        - kind: added
+          description: Option to watch for updates to the mTLS client certificate used by the operator to call Solr pods.
+          links:
+            - name: Github Issue
+              url: https://github.com/apache/solr-operator/issues/317
+            - name: Github PR
+              url: https://github.com/apache/solr-operator/pull/318
+        - kind: added
+          description: Configuration options to support an additional client TLS cert in addition to the server certificate
+          links:
+            - name: Github Issue
+              url: https://github.com/apache/solr-operator/issues/300
+            - name: Github PR
+              url: https://github.com/apache/solr-operator/pull/312
+      artifacthub.io/crds: |
+        - kind: SolrCloud
+          version: v1beta1
+          name: solrcloud.solr.apache.org
+          displayName: Solr Cloud
+          description: A distributed Solr Cloud cluster
+        - kind: SolrPrometheusExporter
+          version: v1beta1
+          name: solrprometheusexporter.solr.apache.org
+          displayName: Solr Prometheus Exporter
+          description: A Prometheus metrics exporter for Solr
+        - kind: SolrBackup
+          version: v1beta1
+          name: solrbackup.solr.apache.org
+          displayName: Solr Backup
+          description: A backup mechanism for Solr
+      artifacthub.io/crdsExamples: |
+        - apiVersion: solr.apache.org/v1beta1
+          kind: SolrCloud
+          metadata:
+            name: example
+          spec:
+            dataStorage:
+              persistent:
+                reclaimPolicy: Delete
+                pvcTemplate:
+                  spec:
+                    resources:
+                      requests:
+                        storage: "20Gi"
+            replicas: 3
+            solrImage:
+              tag: 8.7.0
+            solrJavaMem: "-Xms4g -Xmx4g"
+            customSolrKubeOptions:
+              podOptions:
+                resources:
+                  requests:
+                    memory: "6G"
+            zookeeperRef:
+              provided:
+                replicas: 3
+            solrOpts: "-Dsolr.autoSoftCommit.maxTime=10000"
+            solrGCTune: "-XX:SurvivorRatio=4 -XX:TargetSurvivorRatio=90 -XX:MaxTenuringThreshold=8"
+        - apiVersion: solr.apache.org/v1beta1
+          kind: SolrPrometheusExporter
+          metadata:
+            name: example
+          spec:
+            solrReference:
+              cloud:
+                name: "example"
+            numThreads: 4
+            image:
+              tag: 8.7.0
+      artifacthub.io/images: |
+        - name: solr-operator
+          image: apache/solr-operator:v0.4.0
+      artifacthub.io/links: |
+        - name: "Tutorials"
+          url: https://solr.apache.org/operator/resources#tutorials
+      artifacthub.io/operator: "true"
+      artifacthub.io/operatorCapabilities: Seamless Upgrades
+      artifacthub.io/prerelease: "false"
+      artifacthub.io/recommendations: |
+        - url: https://artifacthub.io/packages/helm/apache-solr/solr
+      artifacthub.io/signKey: |
+        fingerprint: 50E3EE1C91C7E0CB4DFB007B369424FC98F3F6EC
+        url: https://dist.apache.org/repos/dist/release/solr/KEYS
+    apiVersion: v2
+    appVersion: v0.4.0
+    created: "2021-09-13T09:09:04.673575-04:00"
+    dependencies:
+    - condition: zookeeper-operator.install
+      name: zookeeper-operator
+      repository: https://charts.pravega.io
+      version: 0.2.12
+    description: The Solr Operator enables easy management of Solr resources within
+      Kubernetes.
+    digest: 3d0a5236a0f578b34bfa8aa5de066cc7dedcdbb153ff325d8b5d815c53cb4cbf
+    home: https://solr.apache.org/operator
+    icon: https://solr.apache.org/theme/images/identity/Solr_Logo_on_white.png
+    keywords:
+    - solr
+    - apache
+    - search
+    - lucene
+    - operator
+    kubeVersion: '>= 1.16.0-0'
+    maintainers:
+    - email: dev@solr.apache.org
+      name: Solr Dev Community
+    - email: houston@apache.org
+      name: Houston Putman
+    name: solr-operator
+    sources:
+    - https://github.com/apache/solr-operator
+    urls:
+    - https://www.apache.org/dyn/closer.lua/solr/solr-operator/v0.4.0/helm-charts/solr-operator-0.4.0.tgz?action=download&filename=solr/solr-operator/v0.4.0/helm-charts/solr-operator-0.4.0.tgz
+    version: 0.4.0
+  - annotations:
+      artifacthub.io/changes: |
+        - The Solr Operator is now an Apache project managed by the Apache Solr PMC
+        - The Solr CRDs now use the solr.apache.org API group instead of solr.bloomberg.com
+        - The Solr Operator now fully supports running Solr in a secure and locked down way
+        - Basic Auth support is now built in when requested in the SolrCloud CRD
+        - Solr can be run with TLS, with optional mTLS if provided to the operator
+        - More helm chart options are provided to customize running the Solr Operator
+        - The Zookeeper Operator is now up-to-date with the most recent release, v0.2.9
+        - The Zookeeper Operator can now be installed as a helm-chart dependency with the Solr Operator
+        - Users can now provide custom Solr log4j.xml and Prometheus Exporter config xml configMaps
+        - Fix bug in custom probes for Solr pods
+        - Solr pod shutdown is more graceful, has better coordination between Kubernetes and Solr
+        - SolrCloud can now be used with the Kubernetes HPA to autoscale Solr Cloud pods
+      artifacthub.io/crds: |
+        - kind: SolrCloud
+          version: v1beta1
+          name: solrcloud.solr.apache.org
+          displayName: Solr Cloud
+          description: A distributed Solr Cloud cluster
+        - kind: SolrPrometheusExporter
+          version: v1beta1
+          name: solrprometheusexporter.solr.apache.org
+          displayName: Solr Prometheus Exporter
+          description: A Prometheus metrics exporter for Solr
+        - kind: SolrBackup
+          version: v1beta1
+          name: solrbackup.solr.apache.org
+          displayName: Solr Backup
+          description: A backup mechanism for Solr
+      artifacthub.io/crdsExamples: |
+        - apiVersion: solr.apache.org/v1beta1
+          kind: SolrCloud
+          metadata:
+            name: example
+          spec:
+            dataStorage:
+              persistent:
+                reclaimPolicy: Delete
+                pvcTemplate:
+                  spec:
+                    resources:
+                      requests:
+                        storage: "20Gi"
+            replicas: 3
+            solrImage:
+              tag: 8.7.0
+            solrJavaMem: "-Xms4g -Xmx4g"
+            customSolrKubeOptions:
+              podOptions:
+                resources:
+                  requests:
+                    memory: "6G"
+            zookeeperRef:
+              provided:
+                replicas: 3
+            solrOpts: "-Dsolr.autoSoftCommit.maxTime=10000"
+            solrGCTune: "-XX:SurvivorRatio=4 -XX:TargetSurvivorRatio=90 -XX:MaxTenuringThreshold=8"
+        - apiVersion: solr.apache.org/v1beta1
+          kind: SolrPrometheusExporter
+          metadata:
+            name: example
+          spec:
+            solrReference:
+              cloud:
+                name: "example"
+            numThreads: 4
+            image:
+              tag: 8.7.0
+      artifacthub.io/images: |
+        - name: solr-operator
+          image: apache/solr-operator:v0.3.0
+      artifacthub.io/operator: "true"
+      artifacthub.io/operatorCapabilities: Seamless Upgrades
+      artifacthub.io/prerelease: "false"
+    apiVersion: v2
+    appVersion: v0.3.0
+    created: "2021-04-29T13:39:05.588431-05:00"
+    dependencies:
+    - condition: zookeeper-operator.install
+      name: zookeeper-operator
+      repository: https://charts.pravega.io
+      version: 0.2.9
+    description: The Solr Operator enables easy management of Solr resources within
+      Kubernetes.
+    digest: b62a5c33189789a07c59e59c5d4f3072c8c7367c91b8e977e4eb68af9bb16b28
+    home: https://github.com/apache/solr-operator
+    icon: https://solr.apache.org/theme/images/identity/Solr_Logo_on_white.png
+    keywords:
+    - solr
+    - apache
+    - search
+    - lucene
+    - operator
+    kubeVersion: '>= 1.16.0-0'
+    maintainers:
+    - email: dev@solr.apache.org
+      name: Solr Dev Community
+    - email: houston@apache.org
+      name: Houston Putman
+    name: solr-operator
+    sources:
+    - https://github.com/apache/solr-operator
+    urls:
+    - https://www.apache.org/dyn/closer.lua/solr/solr-operator/v0.3.0/helm-charts/solr-operator-0.3.0.tgz?action=download&filename=solr/solr-operator/v0.3.0/helm-charts/solr-operator-0.3.0.tgz
+    version: 0.3.0
+  - annotations:
+      artifacthub.io/changes: |-
+        - This will be the last release of the Bloomberg Solr Operator.
+          All new versions will be release from the Apache organization.
+        - Fixing upgrade issue with new Status fields
+      artifacthub.io/crds: |
+        - kind: SolrCloud
+          version: v1beta1
+          name: solrcloud.solr.bloomberg.com
+          displayName: Solr Cloud
+          description: A distributed Solr Cloud cluster
+        - kind: SolrPrometheusExporter
+          version: v1beta1
+          name: solrprometheusexporter.solr.bloomberg.com
+          displayName: Solr Prometheus Exporter
+          description: A Prometheus metrics exporter for Solr
+        - kind: SolrBackup
+          version: v1beta1
+          name: solrbackup.solr.bloomberg.com
+          displayName: Solr Backup
+          description: A backup mechanism for Solr
+      artifacthub.io/crdsExamples: |
+        - apiVersion: solr.bloomberg.com/v1beta1
+          kind: SolrCloud
+          metadata:
+            name: example
+          spec:
+            dataStorage:
+              persistent:
+                reclaimPolicy: Delete
+                pvcTemplate:
+                  spec:
+                    resources:
+                      requests:
+                        storage: "20Gi"
+            replicas: 3
+            solrImage:
+              tag: 8.7.0
+            solrJavaMem: "-Xms4g -Xmx4g"
+            customSolrKubeOptions:
+              podOptions:
+                resources:
+                  requests:
+                    memory: "6G"
+            zookeeperRef:
+              provided:
+                replicas: 3
+            solrOpts: "-Dsolr.autoSoftCommit.maxTime=10000"
+            solrGCTune: "-XX:SurvivorRatio=4 -XX:TargetSurvivorRatio=90 -XX:MaxTenuringThreshold=8"
+        - apiVersion: solr.bloomberg.com/v1beta1
+          kind: SolrPrometheusExporter
+          metadata:
+            name: example
+          spec:
+            solrReference:
+              cloud:
+                name: "example"
+            numThreads: 4
+            image:
+              tag: 8.7.0
+      artifacthub.io/images: |
+        - name: solr-operator
+          image: bloomberg/solr-operator:v0.2.8
+      artifacthub.io/operator: "true"
+      artifacthub.io/operatorCapabilities: Seamless Upgrades
+      artifacthub.io/prerelease: "false"
+    apiVersion: v1
+    appVersion: v0.2.8
+    created: "2021-01-11T15:21:23.033109-05:00"
+    description: The Solr Operator enables easy management of Solr resources within
+      Kubernetes.
+    digest: 27fcb78a7cf8e76cec6fb99b1aef02224fa25485425266f4e5be20f9b6d04801
+    home: https://github.com/apache/solr-operator
+    icon: https://solr.apache.org/theme/images/identity/Solr_Logo_on_white.png
+    keywords:
+    - solr
+    - apache
+    - search
+    - lucene
+    - operator
+    kubeVersion: '>= 1.16.0-0'
+    maintainers:
+    - email: dev@solr.apache.org
+      name: Solr Dev Community
+    - email: houston@apache.org
+      name: Houston Putman
+    name: solr-operator
+    sources:
+    - https://github.com/apache/solr-operator
+    urls:
+    - https://nightlies.apache.org/solr/release/helm-charts/solr-operator-0.2.8.tgz
+    version: 0.2.8
+  - annotations:
+      artifacthub.io/changes: |
+        - |
+          Kubernetes 1.16+ is required for for this release of the Solr Operator.
+          Please continue using v0.2.6 until you are able to upgrade your Kubernetes cluster.
+        - Removed support for etcd/zetcd deployments.
+        - Deprecations (All deprecations will be removed in v0.3.0)
+        - |
+          The section for a Zookeeper cluster Spec "SolrCloud.spec.zookeeperRef.provided.zookeeper" has been DEPRECATED.
+          The same fields (except for the deprecated persistentVolumeClaimSpec option) are now available under "SolrCloud.spec.zookeeperRef.provided".
+        - Data Storage options have been expanded, and moved from their old locations.
+        - |
+          "SolrCloud.spec.dataPvcSpec" has been DEPRECATED.
+          Please instead use the following instead: "SolrCloud.spec.dataStorage.persistent.pvcTemplate.spec"
+        - |
+          "SolrCloud.spec.backupRestoreVolume" has been DEPRECATED.
+          Please instead use the following instead: "SolrCloud.spec.dataStorage.backupRestoreOptions.Volume"
+        - The SolrCloud and SolrPrometheusExporter services' portNames have changed to "solr-client" and "solr-metrics" from "ext-solr-client" and "ext-solr-metrics", respectivelyi.
+        - |
+          The default PodManagementPolicy for StatefulSets has been changed to Parallel from OrderedReady.
+          This change will not affect existing StatefulSets, as PodManagementPolicy cannot be updated.
+          In order to continue using OrderedReady on new SolrClouds, please use the following setting:
+          "SolrCloud.spec.customSolrKubeOptions.statefulSetOptions.podManagementPolicy"
+        - The location of backup-restore volume mounts in Solr containers has changed from "/var/solr/solr-backup-restore" to "/var/solr/data/backup-restore".
+        - Introduced a managed SolrCloud update strategy
+        - Added PriorityClassName in podOptions
+        - Added option to provide ZK ACLs
+        - Added dataStorage options for SolrCloud - PVC reclaim policy & Ephemeral Volume spec for non-persistent storage
+        - Ability to provide custom solr.xml for SolrCloud
+        - Ability to specify sidecar container and additional initContainers
+        - Gracefully shutdown Solr nodes using the Solr stop port
+        - Adding scope=Namespaced to all CRDs
+        - Move chroot creation logic to pod postStart and out of operator
+        - Change default SolrCloud podManagementPolicy to Parallel from OrderedReady
+        - ZKConnectionString now uses all ZK hosts with Provided ZK
+        - Fix service port name and status URL bugs
+        - Fix never-ending reconcile loop for ZKs
+        - Fix never-ending reconcile loop for ingresses in Kube 1.18+
+        - SolrBackup now works with Solr 8.6+
+        - Fixed an issue with volume permissions in the read-write-many volume for Backups
+        - Remove default imagePullPolicy for pods
+        - Upgraded CRD versions to v1, from v1beta1
+      artifacthub.io/crds: |
+        - kind: SolrCloud
+          version: v1beta1
+          name: solrcloud.solr.bloomberg.com
+          displayName: Solr Cloud
+          description: A distributed Solr Cloud cluster
+        - kind: SolrPrometheusExporter
+          version: v1beta1
+          name: solrprometheusexporter.solr.bloomberg.com
+          displayName: Solr Prometheus Exporter
+          description: A Prometheus metrics exporter for Solr
+        - kind: SolrBackup
+          version: v1beta1
+          name: solrbackup.solr.bloomberg.com
+          displayName: Solr Backup
+          description: A backup mechanism for Solr
+      artifacthub.io/crdsExamples: |
+        - apiVersion: solr.bloomberg.com/v1beta1
+          kind: SolrCloud
+          metadata:
+            name: example
+          spec:
+            dataStorage:
+              persistent:
+                reclaimPolicy: Delete
+                pvcTemplate:
+                  spec:
+                    resources:
+                      requests:
+                        storage: "20Gi"
+            replicas: 3
+            solrImage:
+              tag: 8.7.0
+            solrJavaMem: "-Xms4g -Xmx4g"
+            customSolrKubeOptions:
+              podOptions:
+                resources:
+                  requests:
+                    memory: "6G"
+            zookeeperRef:
+              provided:
+                replicas: 3
+            solrOpts: "-Dsolr.autoSoftCommit.maxTime=10000"
+            solrGCTune: "-XX:SurvivorRatio=4 -XX:TargetSurvivorRatio=90 -XX:MaxTenuringThreshold=8"
+        - apiVersion: solr.bloomberg.com/v1beta1
+          kind: SolrPrometheusExporter
+          metadata:
+            name: example
+          spec:
+            solrReference:
+              cloud:
+                name: "example"
+            numThreads: 4
+            image:
+              tag: 8.7.0
+      artifacthub.io/images: |
+        - name: solr-operator
+          image: bloomberg/solr-operator:v0.2.7
+      artifacthub.io/operator: "true"
+      artifacthub.io/operatorCapabilities: Seamless Upgrades
+      artifacthub.io/prerelease: "false"
+    apiVersion: v1
+    appVersion: v0.2.7
+    created: "2021-01-11T15:21:23.033109-05:00"
+    description: The Solr Operator enables easy management of Solr resources within
+      Kubernetes.
+    digest: 93219551374cbda16be911aed57b86e208072304bafce023fabef39e35e677b1
+    home: https://github.com/apache/solr-operator
+    icon: https://solr.apache.org/theme/images/identity/Solr_Logo_on_white.png
+    keywords:
+    - solr
+    - apache
+    - search
+    - lucene
+    - operator
+    kubeVersion: '>= 1.13.0-0'
+    maintainers:
+    - email: dev@solr.apache.org
+      name: Solr Dev Community
+    - email: houston@apache.org
+      name: Houston Putman
+    name: solr-operator
+    sources:
+    - https://github.com/apache/solr-operator
+    urls:
+    - https://nightlies.apache.org/solr/release/helm-charts/solr-operator-0.2.7.tgz
+    version: 0.2.7
+  - annotations:
+      artifacthub.io/changes: |
+        - Helm chart fixes and improvements
+        - Adding namespace functionality to operator and helm chart
+        - Adding custom addressability options to solrcloud
+        - Adding configurable liveness, readiness, startup checks
+        - Documentation improvements
+      artifacthub.io/crds: |
+        - kind: SolrCloud
+          version: v1beta1
+          name: solrcloud.solr.bloomberg.com
+          displayName: Solr Cloud
+          description: A distributed Solr Cloud cluster
+        - kind: SolrPrometheusExporter
+          version: v1beta1
+          name: solrprometheusexporter.solr.bloomberg.com
+          displayName: Solr Prometheus Exporter
+          description: A Prometheus metrics exporter for Solr
+        - kind: SolrBackup
+          version: v1beta1
+          name: solrbackup.solr.bloomberg.com
+          displayName: Solr Backup
+          description: A backup mechanism for Solr
+      artifacthub.io/crdsExamples: |
+        - apiVersion: solr.bloomberg.com/v1beta1
+          kind: SolrCloud
+          metadata:
+            name: example
+          spec:
+            replicas: 3
+            solrImage:
+              tag: 8.7.0
+            solrJavaMem: "-Xms4g -Xmx4g"
+            customSolrKubeOptions:
+              podOptions:
+                resources:
+                  requests:
+                    memory: "6G"
+            solrOpts: "-Dsolr.autoSoftCommit.maxTime=10000"
+            solrGCTune: "-XX:SurvivorRatio=4 -XX:TargetSurvivorRatio=90 -XX:MaxTenuringThreshold=8"
+        - apiVersion: solr.bloomberg.com/v1beta1
+          kind: SolrPrometheusExporter
+          metadata:
+            name: example
+          spec:
+            solrReference:
+              cloud:
+                name: "example"
+            numThreads: 4
+            image:
+              tag: 8.7.0
+      artifacthub.io/images: |
+        - name: solr-operator
+          image: bloomberg/solr-operator:v0.2.6
+      artifacthub.io/operator: "true"
+      artifacthub.io/operatorCapabilities: Basic Install
+      artifacthub.io/prerelease: "false"
+    apiVersion: v1
+    appVersion: v0.2.6
+    created: "2020-08-10T15:25:32.770735-04:00"
+    description: The Solr Operator enables easy management of Solr resources within
+      Kubernetes.
+    digest: 7c9650262509f1069c74738f4fd9dce4b3eec5198dedf8e710ccb54308756370
+    home: https://github.com/apache/solr-operator
+    icon: https://solr.apache.org/theme/images/identity/Solr_Logo_on_white.png
+    keywords:
+    - solr
+    - apache
+    - search
+    - lucene
+    - operator
+    kubeVersion: '>= 1.13.0-0'
+    maintainers:
+    - email: dev@solr.apache.org
+      name: Solr Dev Community
+    - email: houston@apache.org
+      name: Houston Putman
+    - email: bsankaranara@bloomberg.net
+      name: Balaji Sankaranarayanan
+    name: solr-operator
+    sources:
+    - https://github.com/apache/solr-operator
+    urls:
+    - https://nightlies.apache.org/solr/release/helm-charts/solr-operator-0.2.6.tgz
+    version: 0.2.6
+generated: "2022-03-14T17:28:24.712865-04:00"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
-pelican==4.5.4
+pelican==4.7.2
 Markdown>=3.3.3
 checksumdir>=1.2.0
+markupsafe<2.1
 
 # Pelican plugins
 mdx-include==1.4.1

--- a/themes/solr/templates/htaccess.template
+++ b/themes/solr/templates/htaccess.template
@@ -69,8 +69,8 @@ RedirectMatch Permanent ^/quickstart.html /guide/solr-tutorial.html
 RedirectMatch Permanent ^/docs/4_0_0-(ALPHA|BETA)(.*) /docs/4_0_0$2
 RedirectMatch Permanent ^/docs/api-(.*) /docs/$1
 
-### Redirects to Apache Nightlies, this will change when they have a separate area for released artifacts
-Redirect temp /charts https://nightlies.apache.org/solr/release/helm-charts
+### Redirects to the old nightly charts for local caches of the Solr helm repo that have not been updated recently. We can remove this after some time (maybe a few months).
+RedirectMatch ^/charts/(.+\.tgz.*)$ https://nightlies.apache.org/solr/release/helm-charts/$1
 ### Redirects to Apache Nightlies for pre-Apache Solr Operator CRDs (These don't exist in the archives)
 RedirectMatch ^/operator/downloads/crds/(v0\.2\.6|v0\.2\.7|v0\.2\.8)(/?.*)$ https://nightlies.apache.org/solr/release/operator/crds/$1$2
 ### Redirects to Apache Archives, where the official release CRDs are stored


### PR DESCRIPTION
The individual charts now use the official releases folder, through
closer.lua. Therefore we no longer need to use the nightlies server
or copy any resources to other locations.