### PR TITLE
Use docker for local build and update README

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -16,7 +16,7 @@ github:
     production
 
 notifications:
-  jobs:         janhoy@apache.org
-  issues:       janhoy@apache.org
-  pullrequests: janhoy@apache.org
+  jobs:         builds@solr.apache.org
+  issues:       issues@@solr.apache.org
+  pullrequests: issues@solr.apache.org
   jira_options: link label worklog

--- a/README.md
+++ b/README.md
@@ -4,13 +4,16 @@ This repository contains the "source code" of the Solr website at [solr.apache.o
 
 ## Building the site
 
-The site is written in [Markdown][9] syntax and built into a static site using [Pelican][1]. The site is re-built automatically by [ASF Buildbot][5] on every push to main branch, and the result can be previewed at [solr.staged.apache.org][6]. Build success/failure emails are sent to [commits@solr.apache.org][7] mailing list. Read more about the mechanics behind auto building in [INFRA Confluence][8].
+The site is written in [Markdown][9] syntax and built into a static site using [Pelican][1].
+
+On each Pull Request we do a simple pelican build. The staging site is re-built automatically by Github Actions on every push to `main` branch, and the result can be previewed at [solr.staged.apache.org][6]. Build success/failure emails are sent to [commits@solr.apache.org][7] mailing list.
  
 If the staged site looks good, simply merge the changes to branch `production` and the site will be deployed in a minute or two. Note that simple edits can also be done directly in the GitHub UI rather than clone -> edit -> commit -> push.
 
 > **IMPORTANT**: Please never commit directly to `production` branch. All commits should go to `main, and then merge `main` to `production`. Note that it **is** possible to make a Pull Request for the merge from `main-->production`. If you do so, please merge using a merge commit rather than a squash merge.
 
-For larger edits it is recommended to build and preview the site locally. This lets you see the result of your changes instantly without committing anything. The next sections detail that procedure. The TL;DR instructions goes like this:
+For larger edits it is recommended to build and preview the site locally. This lets you see the result of your changes instantly without committing anything.
+The bundled script uses a pelican docker image to build and serve the site locally. Please make sure you have docker installed.
 
     # Usage: ./build.sh [-l] [<other pelican arguments>]
     #        -l     Live build and reload source changes on localhost:8000
@@ -19,39 +22,13 @@ For larger edits it is recommended to build and preview the site locally. This l
 
 Now go to <http://localhost:8000> to view the beautiful Solr web page served from your laptop with live-preview of updates :)
 
-### Installing Pelican by hand
+### Other options
 
-The site uses [Pelican][1] for static html generation. Pelican requires [Python 3.5+][4] and can be installed with pip.
+If you want to build the site without the docker image, you can install Python 3 and Pelican, see [manual install](./manual-install.md) for details.
 
-**The `build.sh` script mentioned in the above paragraph takes care of setting up your Pelican environment,** and you can skip this part unless you want to understand the moving parts and install things by hand. Assuming that you have python3 installed, simply run:
+On Windows, you can use the Windows Subsystem for Linux (WSL) to run the build script. Or you can run the docker command directly in a Terminal:
 
-```sh
-pip3 install -r requirements.txt
-```
-
-If you run into conflicts with existing packages, a solution is to use a virtual Python environment. See the [Pelican installation page][2] for more details. These are quick commands, Linux flavor:
-
-```sh
-python3 -m venv env
-source env/bin/activate
-pip install -r requirements.txt
-```
-
-Once Pelican is installed you can convert your content into HTML via the pelican command (`content` is the default location to build from).
-
-```sh
-pelican
-```
-
-The above command will generate your site and save it in the `output/` folder using the solr theme and settings defined in `pelicanconf.py`
-
-You can also tell Pelican to watch for your modifications, instead of manually re-running it every time you want to see your changes. To enable this, run the pelican command with the `-r` or `--autoreload` option. On non-Windows environments, this option can also be combined with the `-l` or `--listen` option to simultaneously both auto-regenerate and serve the output through a builtin webserver on <http://localhost:8000>.
-
-```sh
-pelican --autoreload --listen
-```
-
-Remember that on Mac/Linux you can use the `build.sh` script with `-l` option to do the same.
+    docker run --rm -w /work -p 8000:8000 -v $(pwd):/work qwe1/docker-pelican:4.8.0 pip3 install -r requirements.txt; pelican content -r -l -b 0.0.0.0
 
 ## Updating site during a Solr release
 
@@ -80,9 +57,7 @@ Modify `SOLR_LATEST_RELEASE` and `SOLR_PREVIOUS_MAJOR_RELEASE`, and
 [2]: https://docs.getpelican.com/en/stable/install.html
 [3]: https://solr.apache.org/downloads.html#about-versions-and-support
 [4]: https://www.python.org/downloads/
-[5]: https://ci2.apache.org/#/builders/3
 [6]: https://solr.staged.apache.org
 [7]: https://lists.apache.org/list.html?commits@solr.apache.org
-[8]: https://wiki.apache.org/confluence/display/INFRA/Git+-+.asf.yaml+features
 [9]: http://daringfireball.net/projects/markdown/syntax
  

--- a/manual-install.md
+++ b/manual-install.md
@@ -1,0 +1,49 @@
+# Installing Pelican by hand
+
+The site uses [Pelican][1] for static html generation. Pelican requires [Python 3.5+][4] and can be installed with pip.
+
+**The `build.sh` script mentioned in REAME is the easiest way of building the site**, and you can skip this part unless you want to understand the moving parts and install things by hand. 
+
+## Install Python 3
+
+First, you need to install Python 3. You can download the latest version from the [Python website][4] or
+use your package manager to install it. For example, on macOS:
+
+```shell
+brew install python
+```
+
+## Install Pelican
+
+To install pelican and requirements, simply run the following command in the root of the repository:
+
+```sh
+pip3 install -r requirements.txt
+```
+
+If you run into conflicts with existing packages, a solution is to use a virtual Python environment. See the [Pelican installation page][2] for more details. These are quick commands, Linux flavor:
+
+```sh
+python3 -m venv env
+source env/bin/activate
+pip install -r requirements.txt
+```
+
+Once Pelican is installed you can convert your content into HTML via the pelican command (`content` is the default location to build from).
+
+```sh
+pelican
+```
+
+The above command will generate your site and save it in the `output/` folder using the solr theme and settings defined in `pelicanconf.py`
+
+You can also tell Pelican to watch for your modifications, instead of manually re-running it every time you want to see your changes. To enable this, run the pelican command with the `-r` or `--autoreload` option. On non-Windows environments, this option can also be combined with the `-l` or `--listen` option to simultaneously both auto-regenerate and serve the output through a builtin webserver on <http://localhost:8000>.
+
+```sh
+pelican --autoreload --listen
+```
+
+Remember that on Mac/Linux you can use the `build.sh` script with `-l` option to do the same.
+
+[1]: https://blog.getpelican.com/
+[4]: https://www.python.org/downloads/


### PR DESCRIPTION
* Rewrote `build.sh` to use docker under the hood, else same syntax
* Moved manual install instructions to separate md file
* Updated README to mention github actions build
* Add notification emails