### PR TITLE
Improve build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,8 @@ If the staged site looks good, simply merge the changes to branch `production` a
 For larger edits it is recommended to build and preview the site locally. This lets you see the result of your changes instantly without committing anything.
 The bundled script uses a pelican docker image to build and serve the site locally. Please make sure you have docker installed.
 
-    # Usage: ./build.sh [-l] [-b] [<other pelican arguments>]
+    # Usage: ./build.sh [-l] [<other pelican arguments>]
     #        -l     Live build and reload source changes on localhost:8000
-    #        -b     Re-build local docker image, re-installing packages from requirements.txt
     ./build.sh -l
 
 Now go to <http://localhost:8000> to view the beautiful Solr web page served from your laptop with live-preview of updates :)

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ The bundled script uses a pelican docker image to build and serve the site local
 
     # Usage: ./build.sh [-l] [<other pelican arguments>]
     #        -l     Live build and reload source changes on localhost:8000
+    #        --help Show full help for options that Pelican accepts
     ./build.sh -l
 
 Now go to <http://localhost:8000> to view the beautiful Solr web page served from your laptop with live-preview of updates :)

--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ If the staged site looks good, simply merge the changes to branch `production` a
 For larger edits it is recommended to build and preview the site locally. This lets you see the result of your changes instantly without committing anything.
 The bundled script uses a pelican docker image to build and serve the site locally. Please make sure you have docker installed.
 
-    # Usage: ./build.sh [-l] [<other pelican arguments>]
+    # Usage: ./build.sh [-l] [-b] [<other pelican arguments>]
     #        -l     Live build and reload source changes on localhost:8000
-    #        --help Show full help for options that Pelican accepts
+    #        -b     Re-build local docker image, re-installing packages from requirements.txt
     ./build.sh -l
 
 Now go to <http://localhost:8000> to view the beautiful Solr web page served from your laptop with live-preview of updates :)
@@ -28,7 +28,7 @@ If you want to build the site without the docker image, you can install Python 3
 
 On Windows, you can use the Windows Subsystem for Linux (WSL) to run the build script. Or you can run the docker command directly in a Terminal:
 
-    docker run --rm -w /work -p 8000:8000 -v $(pwd):/work qwe1/docker-pelican:4.8.0 pip3 install -r requirements.txt; pelican content -r -l -b 0.0.0.0
+    docker run --rm -ti -w /work -p 8000:8000 -v $(pwd):/work qwe1/docker-pelican:4.8.0 sh -c "pip3 install -r requirements.txt; pelican content -r -l -b 0.0.0.0"
 
 ## Updating site during a Solr release
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ If you want to build the site without the docker image, you can install Python 3
 
 On Windows, you can use the Windows Subsystem for Linux (WSL) to run the build script. Or you can run the docker command directly in a Terminal:
 
-    docker run --rm -ti -w /work -p 8000:8000 -v $(pwd):/work qwe1/docker-pelican:4.8.0 sh -c "pip3 install -r requirements.txt; pelican content -r -l -b 0.0.0.0"
+    docker run --rm -ti -w /work -p 8000:8000 -v $(pwd):/work python:3-alpine sh -c "pip3 install -r requirements.txt; pelican content -r -l -b 0.0.0.0"
 
 ## Updating site during a Solr release
 

--- a/build.sh
+++ b/build.sh
@@ -18,10 +18,9 @@
 set -e
 #set -x
 
-# Using https://hub.docker.com/r/qwe1/docker-pelican as pelican image, supports both AMD64 and ARM64
-PELICAN_IMAGE="qwe1/docker-pelican:4.8.0"
-SOLR_PELICAN_IMAGE="solr-pelican-image"
-DOCKER_CMD="docker run --rm -ti -w /work -p 8000:8000 -v $(pwd):/work $SOLR_PELICAN_IMAGE"
+PYTHON_IMAGE="python:3-alpine"
+SOLR_LOCAL_PELICAN_IMAGE="solr-pelican-image"
+DOCKER_CMD="docker run --rm -ti -w /work -p 8000:8000 -v $(pwd):/work $SOLR_LOCAL_PELICAN_IMAGE"
 unset SERVE
 PIP_CMD="pip3 install -r requirements.txt"
 PELICAN_CMD="pelican content -o output"
@@ -36,16 +35,16 @@ function usage {
 }
 
 function build_image {
-  echo "Building local Docker image for Pelican, called $SOLR_PELICAN_IMAGE."
+  echo "Building local Docker image for Pelican, called $SOLR_LOCAL_PELICAN_IMAGE."
   # Make a new local image with the pip packages installed
   docker rm -f solr-pelican >/dev/null 2>&1 || true
-  docker run --name solr-pelican -w /work -v $(pwd):/work $PELICAN_IMAGE sh -c "$PIP_CMD"
-  docker commit solr-pelican $SOLR_PELICAN_IMAGE
+  docker run --name solr-pelican -w /work -v $(pwd):/work $PYTHON_IMAGE sh -c "$PIP_CMD"
+  docker commit solr-pelican $SOLR_LOCAL_PELICAN_IMAGE
   docker rm -f solr-pelican >/dev/null 2>&1 || true
 }
 
 function ensure_image {
-  if ! docker inspect $SOLR_PELICAN_IMAGE >/dev/null 2>&1
+  if ! docker inspect $SOLR_LOCAL_PELICAN_IMAGE >/dev/null 2>&1
   then
     build_image
   fi

--- a/build.sh
+++ b/build.sh
@@ -28,7 +28,7 @@ PELICAN_OPTS=""
 export SITEURL="https://solr.apache.org/"
 
 function usage {
-   echo "Usage: ./build.sh [-l] [<other pelican arguments>]"
+   echo "Usage: ./build.sh [-l] [-h] [<other pelican arguments>]"
    echo "       -l     Live build and reload source changes on localhost:8000"
    echo "       --help Show full help for options that Pelican accepts"
 }
@@ -103,6 +103,7 @@ while getopts ":lbh-:" opt; do
     - )
       case "${OPTARG}" in
         help )
+          usage
           echo
           echo "Below is a list of other arguments you can use which will be passed to pelican."
           echo

--- a/build.sh
+++ b/build.sh
@@ -97,9 +97,11 @@ ensure_image
 if [[ $SERVE ]]; then
   echo "Building Solr site locally. Goto http://localhost:8000 to view."
   echo "Edits you do to the source tree will be compiled immediately!"
+  echo "Changes to requirements.txt will require using -b option to rebuild the image."
   $DOCKER_CMD sh -c "$PELICAN_CMD --autoreload --listen -b 0.0.0.0 $PELICAN_OPTS $*"
 else
-  echo "Building Solr site."
+  echo "Building Solr site locally."
   echo "To build and serve live edits locally, run this script with -l argument. Use -h for help."
+  echo "Changes to requirements.txt will require using -b option to rebuild the image."
   $DOCKER_CMD sh -c "$PELICAN_CMD $PELICAN_OPTS $*"
 fi

--- a/build.sh
+++ b/build.sh
@@ -14,18 +14,41 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Fail on error
+set -e
+#set -x
+
 # Using https://hub.docker.com/r/qwe1/docker-pelican as pelican image, supports both AMD64 and ARM64
 PELICAN_IMAGE="qwe1/docker-pelican:4.8.0"
-DOCKER_CMD="docker run --rm -w /work -p 8000:8000 -v $(pwd):/work $PELICAN_IMAGE"
+SOLR_PELICAN_IMAGE="solr-pelican-image"
+DOCKER_CMD="docker run --rm -ti -w /work -p 8000:8000 -v $(pwd):/work $SOLR_PELICAN_IMAGE"
 unset SERVE
 PIP_CMD="pip3 install -r requirements.txt"
 PELICAN_CMD="pelican content -o output"
+PELICAN_OPTS=""
 export SITEURL="https://solr.apache.org/"
 
 function usage {
-   echo "Usage: ./build.sh [-l] [<other pelican arguments>]"
+   echo "Usage: ./build.sh [-l] [-b] [<other pelican arguments>]"
    echo "       -l     Live build and reload source changes on localhost:8000"
+   echo "       -b     Re-build local docker image, re-installing packages from requirements.txt"
    echo "       --help Show full help for options that Pelican accepts"
+}
+
+function build_image {
+  echo "Building local Docker image for Pelican, called $SOLR_PELICAN_IMAGE."
+  # Make a new local image with the pip packages installed
+  docker rm -f solr-pelican >/dev/null 2>&1 || true
+  docker run --name solr-pelican -w /work -v $(pwd):/work $PELICAN_IMAGE sh -c "$PIP_CMD"
+  docker commit solr-pelican $SOLR_PELICAN_IMAGE
+  docker rm -f solr-pelican >/dev/null 2>&1 || true
+}
+
+function ensure_image {
+  if ! docker inspect $SOLR_PELICAN_IMAGE >/dev/null 2>&1
+  then
+    build_image
+  fi
 }
 
 if ! docker -v >/dev/null 2>&1
@@ -37,29 +60,46 @@ then
   exit 2
 fi
 
-if [[ ! -z $1 ]]; then
-  if [[ "$1" == "-l" ]]; then
-    SERVE=true
-    shift
-  else
-    usage
-    if [[ "$1" == "-h" ]]; then
+while getopts ":lbh-:" opt; do
+  case ${opt} in
+    l )
+      SERVE=true
+      ;;
+    b )
+      build_image
+      ;;
+    h )
+      usage
       exit 0
-    elif [[ "$1" == "--help" ]]; then
-      echo
-      echo "Below is a list of other arguments you can use which will be passed to pelican."
-      echo
-      $DOCKER_CMD pelican -h
-      exit 0
-    fi
-  fi
-fi
+      ;;
+    - )
+      case "${OPTARG}" in
+        help )
+          echo
+          echo "Below is a list of other arguments you can use which will be passed to pelican."
+          echo
+          $DOCKER_CMD pelican -h
+          exit 0
+          ;;
+        * )
+          PELICAN_OPTS+="--${OPTARG} "
+          ;;
+      esac
+      ;;
+    \? )
+      PELICAN_OPTS+="-${OPTARG} "
+      ;;
+  esac
+done
+shift $((OPTIND -1))
+
+ensure_image
 if [[ $SERVE ]]; then
   echo "Building Solr site locally. Goto http://localhost:8000 to view."
   echo "Edits you do to the source tree will be compiled immediately!"
-  $DOCKER_CMD $PIP_CMD; $PELICAN_CMD --autoreload --listen -b 0.0.0.0 $@
+  $DOCKER_CMD sh -c "$PELICAN_CMD --autoreload --listen -b 0.0.0.0 $PELICAN_OPTS $*"
 else
   echo "Building Solr site."
   echo "To build and serve live edits locally, run this script with -l argument. Use -h for help."
-  $DOCKER_CMD $PIP_CMD; $PELICAN_CMD $@
+  $DOCKER_CMD sh -c "$PELICAN_CMD $PELICAN_OPTS $*"
 fi

--- a/manual-install.md
+++ b/manual-install.md
@@ -1,12 +1,13 @@
 # Installing Pelican by hand
 
-The site uses [Pelican][1] for static html generation. Pelican requires [Python 3.5+][4] and can be installed with pip.
+The site uses [Pelican][1] for static html generation. Pelican requires [Python 3.5+][2] and can be installed with pip.
 
-**The `build.sh` script mentioned in REAME is the easiest way of building the site**, and you can skip this part unless you want to understand the moving parts and install things by hand. 
+**The `build.sh` script mentioned in README is the easiest way of building the site using Docker**.
+If for some reason you want to install Python and Pelican by hand, here are the steps: 
 
 ## Install Python 3
 
-First, you need to install Python 3. You can download the latest version from the [Python website][4] or
+First, you need to install Python 3. You can download the latest version from the [Python website][2] or
 use your package manager to install it. For example, on macOS:
 
 ```shell
@@ -21,7 +22,7 @@ To install pelican and requirements, simply run the following command in the roo
 pip3 install -r requirements.txt
 ```
 
-If you run into conflicts with existing packages, a solution is to use a virtual Python environment. See the [Pelican installation page][2] for more details. These are quick commands, Linux flavor:
+If you run into conflicts with existing packages, a solution is to use a virtual Python environment. See the [Pelican installation page][3] for more details. These are quick commands, Linux flavor:
 
 ```sh
 python3 -m venv env
@@ -43,7 +44,6 @@ You can also tell Pelican to watch for your modifications, instead of manually r
 pelican --autoreload --listen
 ```
 
-Remember that on Mac/Linux you can use the `build.sh` script with `-l` option to do the same.
-
-[1]: https://blog.getpelican.com/
-[4]: https://www.python.org/downloads/
+[1]: https://getpelican.com
+[2]: https://www.python.org/downloads/
+[3]: https://docs.getpelican.com/en/stable/install.html


### PR DESCRIPTION
In #104 I moved the `build.sh` script from requiring a local python and pelican install, to using a docker image locally.

The script has some weaknesses and bugs.
* The chained commands `pip` and `pelican` were not passed correctly to docker runtime, causing error 
    `./build.sh: line 64: pelican: command not found`
* The requirements needed to be pulled every single time

This PR addresses this
* On first run, check if a local image `solr-pelican-image` is present. If not, build the image. If it exists, use it as-is
* Re-build image if `requirements.txt` is newer than latest image build time
* Add proper getopts argument parsing with pass-through of options to pelican (e.g. `-v` for verbose)
* Uses `python:3-alpine` as image, smaller and no need for preinstalled pelican v4.8.0

This all makes for a much faster workflow and less waste of bandwidth.