### PR TITLE
Sort blog posts reverse date

### DIFF
--- a/themes/solr/templates/bloghome.html
+++ b/themes/solr/templates/bloghome.html
@@ -23,7 +23,7 @@
 
   <hr/>
 
-  {% for article in (pages | selectattr("category.name", "in", ["solr/blogposts"]) |list | sort(attribute="locale_date")) %}
+  {% for article in (pages | selectattr("category.name", "in", ["solr/blogposts"]) |list | reverse) %}
   <h2 id="{{ article.slug }}">
     <a href="{{article.url}}">
       {{ article.title }}

--- a/themes/solr/templates/bloghome.html
+++ b/themes/solr/templates/bloghome.html
@@ -23,7 +23,7 @@
 
   <hr/>
 
-  {% for article in (pages | selectattr("category.name", "in", ["solr/blogposts"]) |list | reverse) %}
+  {% for article in (pages | selectattr("category.name", "in", ["solr/blogposts"]) |list | sort(attribute="date") | reverse) %}
   <h2 id="{{ article.slug }}">
     <a href="{{article.url}}">
       {{ article.title }}


### PR DESCRIPTION
I noticed when testing the latest PR #114 locally that the post, dated July 15th, sorted above the existing July 1st post. It is since the template explicitly sorts by the english surface form of the date. Here is a small patch that sorts by reverse of the plain file listing, which already contains the date...