### PR TITLE
Resolve asf.yaml syntax error

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -12,8 +12,8 @@ github:
     merge:  true
     rebase: false
   protected_branches:
-    main
-    production
+    main: {}
+    production: {}
 
 notifications:
   jobs:         builds@solr.apache.org


### PR DESCRIPTION
The operator release process involves some pushes directly to the `main` and `production` branches of this repo.  Both attempts to push triggered a minor error due to a syntax error in this repo's `.asf.yaml`:

```
Total 15 (delta 8), reused 0 (delta 0), pack-reused 0
remote: To github:apache/solr-site.git
remote:    ea9723c82..bc90fbd27  bc90fbd27d5c58deeb550120b09be3ee28827f64 -> main
remote: Syncing refs/heads/main...
remote: Sending notification emails to: ['"commits@solr.apache.org" <commits@solr.apache.org>']
remote: An error occurred while processing the github feature in .asf.yaml: 
remote: 
remote: when expecting a mapping
remote: found arbitrary text
remote:   in "solr-site.git/.asf.yaml::github", line 10, column 1:
remote:     protected_branches: main production
remote:     ^ (line: 10)
remote: 
remote: ---
remote: With regards, ASF Infra.
To https://gitbox.apache.org/repos/asf/solr-site.git
```

This PR fixes this syntax error - each protected branch is expected to be a YAML object rather than a string value.