### PR TITLE
SOLR-17809: Add VEX for CVE-2024-51504 (Zookeeper)

### DIFF
--- a/vex-input.json
+++ b/vex-input.json
@@ -1,6 +1,22 @@
 [
   {
     "ids": [
+      "CVE-2024-51504"
+    ],
+    "versions": "9.4.0\u20139.8.1",
+    "jars": [
+      "zookeeper-3.9.0.jar",
+      "zookeeper-3.9.1.jar",
+      "zookeeper-3.9.2.jar"
+    ],
+    "analysis": {
+      "state": "not_affected",
+      "justification": "requires_configuration",
+      "detail": "Solr production deployments are unlikely to be affected.\nExploitation requires Solr to run in SolrCloud mode with the embedded (non-production) Zookeeper server.\nIt also requires the Zookeeper Admin Server to be manually enabled in the configuration."
+    }
+  },
+  {
+    "ids": [
       "CVE-2024-6763"
     ],
     "versions": "< 9.8",


### PR DESCRIPTION
This change adds a VEX statement for CVE-2024-51504, concluding that the vulnerability is **not exploitable in typical production deployments** of Apache Solr (versions 3.4.0 to 3.8.1). The assessment is based on the following configuration-dependent conditions:

- Solr must be running in [SolrCloud mode](https://solr.apache.org/guide/solr/latest/deployment-guide/cluster-types.html#solrcloud-mode), which uses Zookeeper.
- The [embedded Zookeeper server](https://solr.apache.org/guide/solr/latest/deployment-guide/zookeeper-ensemble.html) must be in use — a configuration **explicitly** discouraged for production environments. Solr logs a warning when this setup is active, supporting the conclusion that it is not commonly used in production.
- The Zookeeper Admin Server must be manually enabled in the `server/solr/zoo.cfg` file. By default, the file contains:
  ```properties
  # Disable ZK AdminServer since we do not use it
  admin.enableServer=false
  ```

Given these requirements, the vulnerability is assessed as:

* Status: `not_affected`
* Justification: `requires_configuration`