### PR TITLE
update _copyright.html - "Apache and the Apache [feather ]logo ..."

### DIFF
--- a/themes/solr/templates/_copyright.html
+++ b/themes/solr/templates/_copyright.html
@@ -1,7 +1,7 @@
 <div class="large-centered columns">
   <p>Copyright © {{ CURRENTYEAR }} The Apache Software Foundation, Licensed under the
     <a href="https://www.apache.org/licenses/LICENSE-2.0">Apache License, Version 2.0</a>. <a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a><br/>
-    Apache and the Apache feather logo are trademarks of The Apache Software Foundation. Apache Lucene,
+    Apache and the Apache logo are trademarks of The Apache Software Foundation. Apache Lucene,
     Apache Solr and their respective logos are trademarks of the Apache Software Foundation.
     Please see the <a href="https://www.apache.org/foundation/marks/">Apache Trademark Policy</a> for more information.
     All non-Apache logos are the trademarks of their respective owners.</p>


### PR DESCRIPTION
Similar to https://github.com/apache/lucene-site/pull/84 for Lucene, matching wording in footer of e.g. https://apache.org/foundation/press/kit/ page.