### PR TITLE
SOLR-17992 First version of MCP web site

### DIFF
--- a/content/doap/solr-mcp.rdf
+++ b/content/doap/solr-mcp.rdf
@@ -1,0 +1,52 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl"?>
+<rdf:RDF xml:lang="en"
+         xmlns="http://usefulinc.com/ns/doap#" 
+         xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" 
+         xmlns:asfext="http://projects.apache.org/ns/asfext#"
+         xmlns:foaf="http://xmlns.com/foaf/0.1/">
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+   
+         https://www.apache.org/licenses/LICENSE-2.0
+   
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+  <Project rdf:about="https://solr.apache.org/mcp">
+    <created>2025-10-26</created>
+    <license rdf:resource="https://spdx.org/licenses/Apache-2.0" />
+    <name>Apache Solr MCP Server</name>
+    <homepage rdf:resource="https://solr.apache.org/mcp" />
+    <asfext:pmc rdf:resource="https://solr.apache.org" />
+    <shortdesc>Model Context Protocol server for Apache Solr</shortdesc>
+    <bug-database rdf:resource="https://github.com/apache/solr-mcp/issues" />
+    <mailing-list rdf:resource="https://solr.apache.org/community.html#mailing-lists-chat" />
+    <download-page rdf:resource="https://solr.apache.org/mcp/downloads.html" />
+    <programming-language>Go</programming-language>
+    <category rdf:resource="https://projects.apache.org/category/cloud" />
+    <category rdf:resource="https://projects.apache.org/category/search"/>
+    <category rdf:resource="https://projects.apache.org/category/go"/>
+    <repository>
+      <GitRepository>
+        <location rdf:resource="https://gitbox.apache.org/repos/asf/solr-mcp.git"/>
+        <browse rdf:resource="https://gitbox.apache.org/repos/asf?p=solr-mcp.git"/>
+      </GitRepository>
+    </repository>
+    <maintainer>
+      <foaf:Person>
+        <foaf:name>Apache Solr Team</foaf:name>
+          <foaf:mbox rdf:resource="mailto:dev@solr.apache.org"/>
+      </foaf:Person>
+    </maintainer>
+    <!-- NOTE: please insert releases in numeric order, NOT chronologically. -->
+  </Project>
+</rdf:RDF>

--- a/content/pages/mcp/community.md
+++ b/content/pages/mcp/community.md
@@ -1,0 +1,42 @@
+Title: Community
+URL: mcp/community.html
+save_as: mcp/community.html
+template: mcp/community
+
+## Support ##
+
+The Solr MCP community provides user support for free through the [users mailing list](#mailing-lists-chat) and [slack channels](#slack).
+
+## Mailing Lists & Chat ##
+
+The Solr MCP server shares mailing lists with its parent project, Apache Solr.
+Available lists can be [found here]({filename}/pages/community.md#mailing-lists-chat).
+
+#### Slack ####
+
+* The project's main Slack channel is `#solr-mcp` in the `the-asf` organization.
+  Link: <https://the-asf.slack.com/archives/C09TVG3BM1P>
+
+## Issue tracker ##
+
+The Solr MCP Server uses [Github issues](https://github.com/apache/solr-mcp/issues) in its repository for issue tracking.
+
+## How To Contribute ##
+
+Looking to contribute to the Solr MCP Server?  Read the [CONTRIBUTING.md](https://github.com/apache/solr-mcp/blob/main/CONTRIBUTING.md) instructions and join us.
+
+## Code of Conduct ##
+
+For a large and diverse community like ours to be friendly, welcoming and respectful, we recognize the need for some guidelines. The project follows [Apache's Code of Conduct statement](https://www.apache.org/foundation/policies/conduct). Please take some time to read and understand it.
+
+If you feel there has been a violation of this code, please point out your concerns publicly in a friendly and matter of fact manner. Nonverbal communication is prone to misinterpretation and misunderstanding. Everyone has bad days and sometimes says things they regret later. Someone else's communication style may clash with yours, but the difference can be amicably resolved. After pointing out your concerns please be generous upon receiving an apology.
+
+Should there be repeated instances of code of conduct violations, or if there is an obvious and severe violation, the Solr PMC may become involved.
+
+### The Apache Way
+
+As an Apache project we strive to follow [The Apache Way](http://theapacheway.com/). If you are new to the community or to open source in general, you may benefit from understanding our core values as a community, and why we operate the way we do.
+
+## Version Control ##
+
+The project's Git repository is found at https://github.com/apache/solr-mcp or the mirror at https://gitbox.apache.org/repos/asf/solr-mcp.git

--- a/content/pages/mcp/downloads.md
+++ b/content/pages/mcp/downloads.md
@@ -1,0 +1,5 @@
+Title: Downloads
+URL: mcp/downloads.html
+save_as: mcp/downloads.html
+template: mcp/downloads
+

--- a/content/pages/mcp/features.md
+++ b/content/pages/mcp/features.md
@@ -1,0 +1,4 @@
+Title: Features
+URL: mcp/features.html
+save_as: mcp/features.html
+template: mcp/features

--- a/content/pages/mcp/index.md
+++ b/content/pages/mcp/index.md
@@ -1,0 +1,4 @@
+Title: Welcome
+URL: mcp/index.html
+save_as: mcp/index.html
+template: mcp/index

--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -18,6 +18,10 @@ SOLR_OPERATOR_LATEST_RELEASE = 'v0.9.1'
 SOLR_OPERATOR_LATEST_RELEASE_DATE = datetime(2025, 3, 25)
 SOLR_OPERATOR_PREVIOUS_MAJOR_RELEASE = 'v0.8.1'
 
+SOLR_MCP_LATEST_RELEASE = 'v0.0.0'
+#SOLR_MCP_LATEST_RELEASE_DATE = datetime(2025, 3, 25)
+#SOLR_MCP_PREVIOUS_MAJOR_RELEASE = 'v0.8.1'
+
 # This string will be appended to all unversioned css and js resources to prevent caching surprises on edits.
 # The theme's htaccess file also sets a cache-control header with longer lifetime, if the v=XXXX query string is added.
 STATIC_RESOURCE_SUFFIX = "?v=%s" % dirhash('themes/solr/static', 'sha1')[-8:]

--- a/themes/solr/static/css/mcp.css
+++ b/themes/solr/static/css/mcp.css
@@ -1,0 +1,1033 @@
+/*
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+*/
+html, body {
+  font-family: 'Helvetica Neue', sans-serif; /* substitute for proxima nova */
+  color: #333;
+}
+
+body {
+  overflow-x:hidden;
+  pointer-events: none;
+}
+
+body > * {
+  pointer-events: auto;
+}
+
+.alignleft {
+  float: left;
+}
+
+.alignright {
+  float: right;
+}
+
+.container {
+  padding: 40px 0;
+}
+
+code, pre {
+  font-family: Menlo, Consolas,"Liberation Mono",Courier,monospace;
+  color:#4F504D;
+}
+
+code {
+  font-weight: 500;
+}
+
+/*
+ * Elements
+ */
+:focus {
+  outline: 0;
+}
+
+.offset {
+  position: relative;
+  top: -150px;
+  padding-top: 150px;
+  margin-bottom: -130px;
+  z-index: -1000;
+}
+
+.offset-medium {
+  position: relative;
+  top: -115px;
+  padding-top: 115px;
+  padding-bottom: 0px;
+  margin-bottom: -115px;
+  z-index: -1000;
+}
+
+.offset-small {
+  position: relative;
+  top: -56px;
+  padding-top: 112px;
+  margin-bottom: -56px;
+  z-index: -1000;
+}
+
+.btn1{
+  border: 1px solid #d1d3d4;
+  background-color:inherit;
+  text-transform: uppercase;
+  color:#000;
+  padding: 0.7em 1em;
+  font-weight: 500;
+  margin: 0;
+}
+.btn1:hover, .btn1:focus {
+  color:#ff833d;
+  background:inherit;
+}
+
+div.centered {
+  text-align: center;
+  padding-top: 32px;
+}
+
+a.btn, button {
+  border: 1px solid #d1d3d4;
+  background-color:inherit;
+  text-transform: uppercase;
+  color:#000;
+  padding: 0.7em 1em;
+  font-weight: 500;
+  margin: 0;
+}
+
+a.btn:hover, a.btn:focus,
+button:hover, button:focus {
+  color:#ff833d;
+  background:inherit;
+}
+
+a.btn.white,
+button.white {
+  color:#fff;
+}
+
+a.btn.white,
+button.white:hover {
+  color:#262130;
+  background:#fff;
+}
+
+/*
+ * Header
+ */
+
+.header-section {
+  position: fixed;
+  z-index: 999;
+  min-width: 100%;
+  background:#865981;
+}
+
+.header-fill {
+  padding-top: 90px;
+}
+
+.top-bar, .top-bar .name {
+  background:#865981;
+  height: 90px;
+}
+
+.top-bar .name .logo {
+  height: 100%;
+  position:relative;
+  left: 15px;
+  padding: 20px 0 25px 0;
+}
+
+.top-bar-section ul li, .top-bar-section li:not(.has-form) a:not(.button) {
+  background: #865981;
+}
+
+.top-bar-section li:not(.has-form) a:not(.btn):hover {
+  background:inherit;
+  color: #25202f;
+}
+
+.top-bar-section .navigation a.selected {
+  color: #25202f;
+}
+
+.top-bar-section li:not(.has-form) a.btn:hover, .top-bar-section li:not(.has-form) a.btn:focus {
+  background:#fff;
+  color: #25202f;
+}
+
+.top-bar-section ul li>a,
+.top-bar-section ul li>a.btn,
+.top-bar.shrink.expanded .top-bar-section ul li>a,
+.top-bar.shrink.expanded .top-bar-section ul li>a.btn {
+  padding: 0 10px !important;
+  transition: all 0.1s ease;
+  text-transform:uppercase;
+  font-size:0.92rem;
+}
+
+.top-bar-section ul li>a.btn {
+  margin: 0;
+  background-color: transparent;
+  text-align:left;
+}
+
+.top-bar.expanded .toggle-topbar a {
+  color:#fff;
+}
+
+.top-bar.expanded .top-bar-section li:not(.has-form) a:not(.btn):hover {
+  background:#fff;
+}
+
+/* full-width nav styles */
+@media only screen and (min-width: 47.5em) {
+  .top-bar-section .navigation {
+    margin: 20px 20px 20px 0;
+  }
+  .top-bar .name .logo {
+    left: 15px;
+  }
+  .top-bar .btn {
+    padding-top: .65rem;
+    padding-bottom: .55rem;
+    top: 2px;
+    text-align:center;
+    border: 1px solid #fff;
+  }
+  .top-bar .btn:hover {
+    background:#fff;
+  }
+}
+
+/* shrink header styles */
+.top-bar.shrink, .top-bar.shrink .name, .top-bar.expanded .name {
+  height: 55px;
+}
+
+.top-bar.shrink.expanded {
+  height:auto;
+}
+
+.top-bar.shrink .name .logo, .top-bar.expanded .name .logo {
+  padding: 10px 0 15px 0;
+}
+
+.top-bar.shrink .top-bar-section ul li>a, .top-bar.shrink .top-bar-section ul li>a.btn {
+  font-size: 0.8em;
+}
+
+.top-bar.shrink .top-bar-section li:not(.has-form) a:not(.button) {
+  line-height: 35px;
+}
+
+.top-bar.shrink .navigation {
+  margin: 10px 15px 10px 0;
+}
+
+.top-bar.shrink.expanded .navigation {
+  margin: 0;
+}
+
+.top-bar.shrink.expanded .top-bar-section li:not(.has-form) a:not(.button) {
+  line-height: 1.6;
+}
+
+.top-bar.shrink .button {
+  padding: 10px 20px;
+}
+
+/*
+ * Global
+ */
+h1, h2, h3, h4, h5 {
+  font-family: 'Raleway', 'Helvetica Neue', sans-serif;
+  font-weight:300;
+}
+
+h1 {
+  margin-bottom: 20px;
+  color: #865981;
+}
+
+h2 {
+  margin-bottom: 0.8em;
+  color: #865981;
+}
+
+h3 {
+  color: #666;
+}
+
+h4 {
+  color: #666;
+}
+
+h5 {
+  color: #999;
+}
+
+p {
+  line-height: 1.8em;
+  color:#262130;
+}
+
+.button {
+  background-color: #ff833d;
+  text-transform: uppercase;
+}
+
+.button:hover,
+.button:focus,
+.button:active {
+  background-color: #ff5c00;
+}
+
+.annotation {
+  color: #262130;
+  text-transform: uppercase;
+  margin-bottom: 0.8em;
+  font-weight:400;
+}
+
+/*
+ * PAGES
+ */
+
+.homepage h1.red {
+  color: #865981;;
+}
+
+.page h1, .page h2, .page h3 {
+  font-family: 'Raleway', 'Helvetica Neue', sans-serif;
+  color: #262130;
+}
+
+.page h1, .subnav h1 , h1.news {
+  font-weight:300;
+}
+
+.subnav h1 , h1.news {
+  margin-bottom: 30px;
+}
+
+.subnav h1 , h1.news {
+  line-height:0.8;
+}
+
+.page h1 small, .subnav h1 small, h1.news small {
+  font-size:0.4em;
+  color:#333;
+}
+
+.page h2, .page h3 {
+  font-weight:500;
+}
+
+.page h2 {
+  font-size:1.5em;
+}
+
+.page h3 {
+  font-size:1.4em;
+}
+
+.page p, .page ul li, .page ol li {
+  color:#333;
+}
+
+.page a {
+  color: #865981;
+}
+
+.page .date {
+  color: #865981;
+  text-transform:uppercase;
+  font-weight:500;
+}
+
+#resources {
+  text-align:center;
+}
+
+pre {
+  white-space:pre-wrap;
+  overflow:hidden;
+}
+
+/*
+ * Alternate styles (blue sections)
+ */
+.alternate .annotation {
+  color: #865981;
+}
+
+.alternate h1 {
+  font-weight: 100;
+  color: #212121;
+}
+
+.alternate h2 {
+  font-weight: 300;
+}
+
+hr {
+  margin-bottom: 2em;
+  color:#e4e2dd;
+}
+
+/*
+ * Small styles
+ */
+
+.small h1 {
+  font-size: 2em;
+}
+
+.small h2 {
+  font-size: 1.6em;
+}
+
+.small h3 {
+  font-size: 1.4em;
+}
+
+.small h4 {
+  font-size: 1.2em;
+}
+
+.small h5 {
+  font-size: 1em;
+}
+
+.small p {
+  font-size: 0.9em;
+}
+
+/*
+ * Section styles
+ */
+section {
+  padding: 40px 0;
+  color: #333;
+  text-align:center;
+}
+
+.artifacthub-widget > section {
+  padding: 0;
+}
+
+section.gray {
+  background-color: #f9f8f8;
+}
+
+section.orange {
+  background-color: #865981;
+  color: #fff;
+  padding:60px 0 80px 0;
+  text-align:center;
+  position:relative;
+}
+
+section.orange .annotation {
+  color:#fff;
+}
+
+section.orange h1 {
+  color: inherit;
+}
+
+section.orange h2 {
+  color: inherit;
+}
+
+section.orange p {
+  color:#fff;
+  font-weight: 300;
+  font-size: 1.1em;
+}
+
+section.orange .down-arrow {
+  position: absolute;
+  left: 50%;
+}
+
+section.orange .down-arrow .red {
+  color: #ff833c;
+}
+
+section.orange .down-arrow a {
+  color:#fff;
+}
+
+section.orange.full-width {
+  margin-left: -100%;
+  margin-right: -100%;
+  margin-bottom: 2em;
+}
+
+
+/*
+ * Hero
+ */
+.hero {
+  background-color: #262130;
+  color: #fff;
+  position:relative;
+  padding: 100px 0;
+}
+
+.hero h1,
+.hero p {
+  color: #fff;
+}
+
+.hero p {
+  margin-bottom: 40px;
+  font-weight: 300;
+  font-size: 1.1em;
+}
+
+.hero .button {
+  background-color: #305cb3;
+}
+
+.hero .button:hover,
+.hero .button:focus,
+.hero .button:active {
+  background-color: #0045cd;
+}
+
+.hero .down-arrow {
+  position: absolute;
+  bottom: -80px;
+  left: 50%;
+}
+
+.hero .down-arrow .red {
+  color: #865981;
+}
+
+.hero .down-arrow a {
+  color:#fff;
+}
+
+.security {
+  background-color: #FFBF78;
+  padding-top: 10px;
+  padding-bottom: 0px;
+  display: none;
+}
+
+.security a {
+  color: #262130;
+}
+
+.topnews {
+  background-color: #59BD81;
+  padding-top: 15px;
+  padding-bottom: 0px;
+  display: none;
+}
+
+.topnews .row p a {
+  color: #262130;
+  font-size: larger;
+}
+
+.topnews-operator {
+  background-color: #59BD81;
+  padding-top: 15px;
+  padding-bottom: 0px;
+  display: none;
+}
+
+.topnews-operator .row p a {
+  color: #262130;
+  font-size: larger;
+}
+
+/*
+ * Footer
+ */
+footer {
+  background-color: #262130;
+  color: #f9f8f8;
+  padding: 40px 0 20px 0;
+}
+
+footer h4 {
+  padding-bottom:15px;
+  text-transform:uppercase;
+  font-size: 1em;
+}
+
+footer h4, footer ul li a, .page footer ul li a  {
+  color: #f9f8f8;
+  font-family: 'Raleway', 'Helvetica Neue', sans-serif;
+}
+
+footer ul li a, .page footer ul li a {
+  font-weight:300;
+  font-size:0.9em;
+}
+
+footer ul {
+  list-style: none;
+  margin-left: 0;
+}
+
+footer .copyright {
+  padding: 50px 0 40px 0;
+}
+
+footer .copyright p {
+  color: #bbb;
+  font-size:0.7em;
+  text-align:center;
+}
+
+/*
+ * Gray/white section styles
+ */
+
+.white h1 {
+  line-height:0.8;
+}
+
+.gray .annotation {
+  color: #262130;
+  font-size: 1em;
+}
+
+.gray h1 {
+  color: #865981;
+  line-height:0.8;
+}
+
+.gray .box h3 {
+  color:#000;
+  font-size:1.4em;
+  margin-bottom:20px;
+}
+
+.gray .box p {
+  font-size: 0.9em;
+  line-height: 1.3em;
+  color:#333;
+}
+
+.gray .box button {
+  font-size: 0.75em;
+  margin-bottom: 0;
+}
+
+.gray .box button:hover {
+  background-color:inherit;
+  color:#ff833d;
+}
+
+.gray .box:hover {
+  background:#fff;
+  border: 1px solid #333;
+  cursor:pointer;
+}
+
+.gray .box:hover button {
+  color:#ff833d;
+}
+
+.gray .box .img {
+  height:120px;
+}
+
+.gray .box .img img {
+  height:95px;
+}
+
+.full-width .gray .box {
+  padding:0;
+  border:none;
+}
+
+.full-width .gray .box:hover {
+  border:none;
+  cursor:default;
+  background:inherit;
+}
+
+/* box variants */
+.col-4 .box {
+  margin: 15px;
+  padding: 5px 5px 15px 5px;
+  border: solid 1px transparent
+}
+
+.col-4 .box .title {
+  height: 70px;
+}
+
+.col-3 .box {
+  margin: 15px;
+  padding: 20px 20px 30px 20px;
+  border: solid 1px transparent
+}
+
+.col-3 .box .title {
+  height: 70px;
+}
+
+[class*="block-grid-"] {
+  display: flex;
+  padding: 0;
+  margin:0;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+/*
+ * Solr books
+ */
+.books {
+  margin:40px 0;
+
+}
+
+.books > div{
+  padding-left: 5px;
+}
+
+.powered{
+  line-height: 99px;
+  height: 99px;
+}
+.powered div{
+  line-height: 99px;
+  height: 99px;
+  padding-right: 10px;
+}
+
+.powered img{
+  vertical-align: middle;
+  display: inline;
+}
+
+/*
+ * Slider
+ * TODO: Not in use
+ */
+.slider-prev {
+  left:-25px;
+  color:#ffa16b;
+}
+
+.slider-next {
+  right:-25px;
+  color:#ffa16b;
+}
+
+.slider-prev, .slider-next {
+  position: absolute;
+  display: block;
+  height: 20px;
+  width: 20px;
+  cursor: pointer;
+  top: 50%;
+  margin-top: -10px;
+}
+
+/*
+ * FEATURES PAGE
+ */
+section.list {
+  padding:80px 0;
+}
+
+section.list {
+  text-align:left;
+}
+
+section.list ul li {
+  font-family: 'Raleway', 'Helvetica Neue', sans-serif;
+  font-weight:300;
+  color: #333;
+  font-size: 1.2em;
+  padding-right:20px;
+}
+
+section.list ul li p {
+  font-family: 'Helvetica Neue', sans-serif;
+  font-weight:300;
+  color: #A13016;
+  margin-top: 10px;
+  font-size: 0.8em;
+}
+
+section.list ul li ul {
+  padding-top: 10px;
+}
+
+section.list ul li ul li {
+  font-family: 'Helvetica Neue', sans-serif;
+  font-weight:300;
+  color: #A13016;
+  margin-top: 2px;
+  font-size: 0.96em;
+}
+
+
+.anchor-fixed {
+  top: 57px;
+  z-index: 1000;
+  position: fixed;
+}
+
+/*
+ * Subnav style pages
+ */
+.sub-nav {
+  display:inline-block;
+  margin-bottom:0;
+}
+
+.sub-nav-container {
+  height: 100px;
+  width: 1000px;
+  margin: 0 auto;
+}
+
+.sub-nav-border {
+  padding: 20px 0;
+  background: white;
+  border-top: 1px solid #e4e2dd;
+  border-bottom: 1px solid #e4e2dd;
+  margin: 0 auto 30px auto;
+}
+
+.sub-nav dd {
+  margin-bottom: 0;
+}
+
+.sub-nav dd a {
+  padding-right: 30px;
+  padding-left: 15px;
+  border-right:1px solid #e4e2dd;
+  position: relative;
+  z-index: 2000;
+}
+
+.codehilite {
+  margin: 10px 0;
+  background-color: #EEEEEE;
+  padding-top: 5px;
+  padding-bottom: 5px;
+  padding-left: 15px;
+}
+
+pre {
+  line-height:1.5;
+}
+
+ul.breadcrumbs {
+  background-color:transparent;
+  border: none;
+}
+
+/*
+ * Sidebar
+ */
+
+.side-nav {
+  padding:25px;
+  border:1px solid #e4e2dd;
+  margin-bottom:40px;
+}
+
+ul.side-nav > li {
+  border-top:1px solid #e4e2dd;
+  padding:10px 0 10px 10px;
+  margin:0;
+}
+
+.page .side-nav li a {
+  color:#25202f;
+  font-weight:300;
+  font-size: 1.3em;
+}
+
+.page .side-nav li a.active {
+  color:#865981;
+}
+
+.page .side-nav li a:hover {
+  color:#865981;
+}
+
+#search form, #search fieldset {
+  border:none;
+  padding:0;
+  margin:0;
+}
+
+.search-box {
+  display: inline-block;
+  padding-right: 1em;
+  position: relative;
+  width: 150px;
+  height: 42px;
+}
+
+#search input[type="search"] {
+  font-family: 'Raleway', 'Helvetica Neue', sans-serif;
+  font-weight:300;
+  height: 28px;
+  width: 135px;
+  font-size: 12px;
+  border: none;
+  box-shadow: none;
+  position: absolute;
+  top: 8px;
+  left: 0px;
+  padding-right: 26px;
+}
+
+#search input[type="search"]:focus {
+  background-color: #f9f9f9;
+}
+
+.search-button {
+  position:absolute;
+  height:23px;
+  width:23px;
+  background-color: transparent !important;
+  line-height: 23px !important;
+  padding: 0 !important;
+  top: 10px;
+  right: 17px;
+  margin:0;
+}
+
+.search-button img {
+  padding:0;
+  line-height:23px;
+  margin:0;
+}
+
+.nested-nav {
+
+}
+
+ul.breadcrumbs {
+  margin:0;
+  padding:0;
+}
+
+ul.breadcrumbs a {
+  text-transform:none;
+  font-size:1.2em;
+}
+
+.tutorials .orange {
+  margin-top: 40px;
+  margin-bottom:40px;
+}
+
+.float-right {
+  float: right;
+}
+
+img.float-right {
+  margin: 5px 0px 10px 10px;
+}
+
+
+.poweredby .list ul{
+  list-style-type: none;
+}
+
+.wrappable-btn {
+  border: 1px solid #d1d3d4;
+  background-color: inherit;
+  text-transform: uppercase;
+  color: #000;
+  padding: 0.25em 0.75em 0.05em 0.47em;
+  font-weight: 500;
+  margin: 0;
+  display: inline-block;
+  vertical-align: middle;
+}
+.wrappable-btn:hover, .wrappable-btn:focus {
+  color: #ff833d;
+  background: inherit;
+}
+
+.ref-guide-badge {
+  background-color: #865981;
+  color: #fff;
+  display: inline-block;
+  text-align: center;
+  font-size: 0.6em;
+  line-height: 1.1;
+  font-weight: 500;
+  vertical-align: middle;
+  padding: 1px 2px;
+  margin: 0em 0.50em 0.30em -0.40em;
+}
+.wrappable-btn:hover .ref-guide-badge, .wrappable-btn:focus .ref-guide-badge {
+  background-color: #ff833d;
+}
+
+ul li div.box div.img img.resizeable-solr-logo {
+  max-width:243px;
+  max-height:123px;
+  height:auto;
+  width: 100%;
+  border:2px solid #CCC
+}
+
+ul li div.box h3.fixed-wrap-point-logo-title {
+  padding-left:9px;
+  padding-right:8px;
+}
+
+section h3.asset-download {
+  text-align: left;
+  padding-top: 10px;
+}
+
+ul li div.box div.img.logo-container {
+  padding: 20px;
+  height: auto;
+  width: auto;
+}
+ul li div.box div.img.logo-container.black-background {
+  background-color:#000;
+}
+ul li div.box div.img.logo-container.white-background {
+  background-color:#fff;
+}
+ul li div.box div.img.logo-container.orange-background {
+  background-color:#865981;
+}
+.full-width .gray .box.logo-box {
+  position: relative;
+  border: 1px solid #CCC;
+}

--- a/themes/solr/static/css/mcp.css
+++ b/themes/solr/static/css/mcp.css
@@ -137,7 +137,7 @@ button.white:hover {
   position: fixed;
   z-index: 999;
   min-width: 100%;
-  background:#865981;
+  background:#2d7a3e;
 }
 
 .header-fill {
@@ -145,7 +145,7 @@ button.white:hover {
 }
 
 .top-bar, .top-bar .name {
-  background:#865981;
+  background:#2d7a3e;
   height: 90px;
 }
 
@@ -157,7 +157,7 @@ button.white:hover {
 }
 
 .top-bar-section ul li, .top-bar-section li:not(.has-form) a:not(.button) {
-  background: #865981;
+  background: #2d7a3e;
 }
 
 .top-bar-section li:not(.has-form) a:not(.btn):hover {
@@ -265,12 +265,12 @@ h1, h2, h3, h4, h5 {
 
 h1 {
   margin-bottom: 20px;
-  color: #865981;
+  color: #2d7a3e;
 }
 
 h2 {
   margin-bottom: 0.8em;
-  color: #865981;
+  color: #2d7a3e;
 }
 
 h3 {
@@ -313,7 +313,7 @@ p {
  */
 
 .homepage h1.red {
-  color: #865981;;
+  color: #2d7a3e;;
 }
 
 .page h1, .page h2, .page h3 {
@@ -355,11 +355,11 @@ p {
 }
 
 .page a {
-  color: #865981;
+  color: #2d7a3e;
 }
 
 .page .date {
-  color: #865981;
+  color: #2d7a3e;
   text-transform:uppercase;
   font-weight:500;
 }
@@ -374,10 +374,10 @@ pre {
 }
 
 /*
- * Alternate styles (blue sections)
+ * Alternate styles (green sections)
  */
 .alternate .annotation {
-  color: #865981;
+  color: #2d7a3e;
 }
 
 .alternate h1 {
@@ -440,7 +440,7 @@ section.gray {
 }
 
 section.orange {
-  background-color: #865981;
+  background-color: #2d7a3e;
   color: #fff;
   padding:60px 0 80px 0;
   text-align:center;
@@ -523,7 +523,7 @@ section.orange.full-width {
 }
 
 .hero .down-arrow .red {
-  color: #865981;
+  color: #2d7a3e;
 }
 
 .hero .down-arrow a {
@@ -619,7 +619,7 @@ footer .copyright p {
 }
 
 .gray h1 {
-  color: #865981;
+  color: #2d7a3e;
   line-height:0.8;
 }
 
@@ -874,11 +874,11 @@ ul.side-nav > li {
 }
 
 .page .side-nav li a.active {
-  color:#865981;
+  color:#2d7a3e;
 }
 
 .page .side-nav li a:hover {
-  color:#865981;
+  color:#2d7a3e;
 }
 
 #search form, #search fieldset {
@@ -980,7 +980,7 @@ img.float-right {
 }
 
 .ref-guide-badge {
-  background-color: #865981;
+  background-color: #2d7a3e;
   color: #fff;
   display: inline-block;
   text-align: center;
@@ -1025,7 +1025,7 @@ ul li div.box div.img.logo-container.white-background {
   background-color:#fff;
 }
 ul li div.box div.img.logo-container.orange-background {
-  background-color:#865981;
+  background-color:#2d7a3e;
 }
 .full-width .gray .box.logo-box {
   position: relative;

--- a/themes/solr/templates/_header.html
+++ b/themes/solr/templates/_header.html
@@ -29,7 +29,7 @@
             <a href="{{ SITEURL }}/whoweare.html">Project</a>
           </li>
           <li>
-            <a href="{{ SITEURL }}/operator/">K8S Operator</a>
+            <a href="{{ SITEURL }}/operator/">Solr Operator</a>
           </li>
           <li>
             <a href="{{ SITEURL }}/mcp/">MCP</a>

--- a/themes/solr/templates/index.html
+++ b/themes/solr/templates/index.html
@@ -130,6 +130,18 @@
           </div>
         </a>
       </li>
+      <li>
+        <a href="/mcp">
+          <div class="box">
+            <div class="img"><img src="{{ SITEURL }}/theme/images/Solr_Icons_easy_ways_to_pull_in_data.svg"/></div>
+            <div class="title">
+              <h3>MCP Server</h3>
+            </div>
+            <p>Give your LLM Solr superpowers</p>
+            <span class="btn1">Try it</span>
+          </div>
+        </a>
+      </li>    
     </ul>
   </div>
 </section>

--- a/themes/solr/templates/mcp/_css.html
+++ b/themes/solr/templates/mcp/_css.html
@@ -1,0 +1,8 @@
+<link rel="stylesheet" href="{{ SITEURL }}/theme/css/google-fonts-raleway.css{{ STATIC_RESOURCE_SUFFIX }}" />
+<link rel="stylesheet" href="{{ SITEURL }}/theme/css/google-fonts-kalam.css{{ STATIC_RESOURCE_SUFFIX }}" />
+<link rel="stylesheet" href="{{ SITEURL }}/theme/css/font-awesome.min.css{{ STATIC_RESOURCE_SUFFIX }}" />
+<link rel="stylesheet" href="{{ SITEURL }}/theme/css/lib/foundation/normalize.css{{ STATIC_RESOURCE_SUFFIX }}" />
+<link rel="stylesheet" href="{{ SITEURL }}/theme/css/lib/foundation/foundation.min.css{{ STATIC_RESOURCE_SUFFIX }}"/>
+<link rel="stylesheet" href="{{ SITEURL }}/theme/css/lib/foundation/foundation-icons.css{{ STATIC_RESOURCE_SUFFIX }}"/>
+{#<link rel="stylesheet" type="text/css" href="//cdn.jsdelivr.net/jquery.slick/1.3.7/slick.css"/>#}
+<link rel="stylesheet" href="{{ SITEURL }}/theme/css/mcp.css{{ STATIC_RESOURCE_SUFFIX }}" />

--- a/themes/solr/templates/mcp/_footer.html
+++ b/themes/solr/templates/mcp/_footer.html
@@ -1,0 +1,30 @@
+<div class="row">
+  <div class="small-6 medium-3 columns">
+    <h4>Features</h4>
+    <ul>
+      <li><a href="/mcp/features.html">Overview</a></li>
+      <li><a href="/mcp/features.html#solr-cloud">Solr Cloud</a></li>
+      <li><a href="/mcp/features.html#solr-metrics">Solr Metrics</a></li>
+      <li><a href="/mcp/features.html#solr-backup">Solr Backups</a></li>
+    </ul>
+  </div>
+  <div class="small-6 medium-3 columns">
+    <h4>Community</h4>
+    <ul>
+      <li><a href="/mcp/community.html#support">Support</a></li>
+      <li><a href="/mcp/community.html#mailing-lists-irc">Mailing Lists & Chat</a></li>
+      <li><a href="/mcp/community.html#issue-tracker">Issues</a></li>
+      <li><a href="/mcp/community.html#how-to-contribute">Contribute</a></li>
+      <li><a href="/mcp/community.html#version-control">Version control (GIT)</a></li>
+    </ul>
+  </div>
+  <div class="small-6 medium-3 columns">
+    <h4>Related Projects</h4>
+    <ul>
+      <li><a href="https://lucene.apache.org/">Apache Lucene</a></li>
+    </ul>
+  </div>
+</div>
+<div class="row copyright">
+  {% include "_copyright.html" %}
+</div>

--- a/themes/solr/templates/mcp/_head.html
+++ b/themes/solr/templates/mcp/_head.html
@@ -1,0 +1,25 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE- 2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<meta name="viewport" content="minimal-ui, initial-scale=1, maximum-scale=1, user-scalable=0">
+
+{% include "mcp/_css.html" %}
+
+<meta name="Distribution" content="Global"/>
+<meta name="Robots" content="index,follow"/>
+
+{% include "_javascript.html" %}

--- a/themes/solr/templates/mcp/_header.html
+++ b/themes/solr/templates/mcp/_header.html
@@ -3,7 +3,7 @@
     <nav class="top-bar" data-topbar role="navigation">
       <ul class="title-area">
         <li class="name">
-          <a href="/"><img class="logo" src="{{ SITEURL }}/theme/images/logo.svg" /></a>
+          <a href="{{ SITEURL }}/mcp/"><img class="logo" src="{{ SITEURL }}/theme/images/logo.svg" /></a>
         </li>
         <li class="toggle-topbar menu-icon"><a href="#"><span>Menu</span></a></li>
       </ul>
@@ -11,28 +11,13 @@
       <div class="top-bar-section">
         <ul class="navigation right">
           <li>
-            <a href="{{ SITEURL }}/posts.html">News</a>
+            <a href="{{ SITEURL }}/mcp/features.html">Features</a>
           </li>
           <li>
-            <a href="{{ SITEURL }}/security.html">Security</a>
+            <a href="{{ SITEURL }}/mcp/downloads.html">Downloads</a>
           </li>
           <li>
-            <a href="{{ SITEURL }}/features.html">Features</a>
-          </li>
-          <li>
-            <a href="{{ SITEURL }}/resources.html">Resources</a>
-          </li>
-          <li>
-            <a href="{{ SITEURL }}/community.html">Community</a>
-          </li>
-          <li>
-            <a href="{{ SITEURL }}/whoweare.html">Project</a>
-          </li>
-          <li>
-            <a href="{{ SITEURL }}/operator/">K8S Operator</a>
-          </li>
-          <li>
-            <a href="{{ SITEURL }}/mcp/">MCP</a>
+            <a href="{{ SITEURL }}/mcp/community.html">Community</a>
           </li>
 <!-- TODO Search not working as of feb 2021, disabling
           <li class="toggle">
@@ -43,7 +28,7 @@
           </li>
 -->
           <li>
-            <a class="btn" href="/downloads.html">Download</a>
+            <a class="btn" href="{{ SITEURL }}/">ᐱ Solr TLP</a>
           </li>
         </ul>
       </div>

--- a/themes/solr/templates/mcp/base.html
+++ b/themes/solr/templates/mcp/base.html
@@ -1,0 +1,46 @@
+<!doctype html>
+<html>
+  <head>
+    {% include "mcp/_head.html" %}
+    <title>{% block title %}{{ page.title }}{% endblock %} - Apache Solr MCP Server</title>
+    {% block css %}{% endblock %}
+
+    {% block metakeys %}
+    <meta name="keywords"
+          content="apache, apache solr, solr, apache solr mcp server, solr mcp, ai, model context protocol,
+                   search, information retrieval, inverted index, open source"/>
+   {% endblock %}
+    {% block ogmeta %}
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://solr.apache.org/{{ page.url }}"/>
+    <meta property="og:title" content="{{ page.title }}"/>
+    <meta property="og:description" content="{{ page.content | striptags | replace("\"", "&quot;") | truncate(137, False, '...') }}"/>
+    <meta property="og:image" content="https://solr.apache.org/theme/images/solr_og_image.png{{ STATIC_RESOURCE_SUFFIX }}"/>
+    <meta property="og:image:secure_url" content="https://solr.apache.org/theme/solr/solr_og_image.png{{ STATIC_RESOURCE_SUFFIX }}"/>
+    {% endblock %}
+
+   {% block favicon %}
+   <link rel="icon" href="{{ SITEURL }}/theme/images/favicon.ico" type="image/x-icon">
+   <link rel="shortcut icon" href="{{ SITEURL }}/theme/images/favicon.ico" type="image/x-icon">
+   {% endblock %}
+   {% block rss %}{% endblock %}
+   {% block javascript %}{% endblock %}
+   {% include "_matomo.html" %}
+  </head>
+
+  <body class="page {% block bodyclass %}{% endblock %}" {% block ng_directives %}{% endblock %} x-ng-app="page" x-ng-controller="page.controllers.main">
+    {% include "mcp/_header.html" %}
+
+    {% block solr_security_warning %}
+    {% endblock %}
+    {% block hero_header %}
+    {% endblock %}
+    {% block content %}
+    {% endblock %}
+    <footer>
+      {% include "mcp/_footer.html" %}
+    </footer>
+
+    {% include "_last_scripts.html" %}
+  </body>
+</html>

--- a/themes/solr/templates/mcp/community.html
+++ b/themes/solr/templates/mcp/community.html
@@ -1,0 +1,13 @@
+{% extends "mcp/subnav.html" %}
+
+{% block subnav_title %}Community{% endblock %}
+{% block subnav_subtitle %}Join the active community of Solr MCP Server<sup>&trade;</sup> contributors.{% endblock %}
+{% block subnav_nav_items %}
+<dd><a data-scroll href="#support">Support</a></dd>
+<dd><a data-scroll href="#mailing-lists-chat">Lists/Chat</a></dd>
+<dd><a data-scroll href="#issue-tracker">Issues</a></dd>
+<dd><a data-scroll href="#how-to-contribute">Contributing</a></dd>
+<dd><a data-scroll href="#code-of-conduct">Code of Conduct</a></dd>
+<dd><a data-scroll href="#version-control">Version Control</a></dd>
+<dd><a data-scroll href="#powered-by">Powered By</a></dd>
+{% endblock %}

--- a/themes/solr/templates/mcp/downloads.html
+++ b/themes/solr/templates/mcp/downloads.html
@@ -1,0 +1,20 @@
+{% extends "mcp/page.html" %}
+
+{% block content_inner %}
+<div class="small-12 columns">
+  <style type="text/css">
+    .headerlink, .elementid-permalink {
+      visibility: hidden;
+    }
+    h2:hover > .headerlink, h3:hover > .headerlink, h1:hover > .headerlink, h6:hover > .headerlink, h4:hover > .headerlink, h5:hover > .headerlink, dt:hover > .elementid-permalink {
+      visibility: visible
+    }
+  </style>
+
+  <h1 id="mcp-downloads">{{ page.title }}
+    <a class="headerlink" href="#mcp-downloads" title="Permanent link">¶</a>
+  </h1>
+  {{ page.content }}
+  <p>This project is incubating and has not made any releases yet.</p>
+</div>
+{% endblock content_inner %}

--- a/themes/solr/templates/mcp/features.html
+++ b/themes/solr/templates/mcp/features.html
@@ -1,109 +1,188 @@
 {% extends "mcp/fullwidth.html" %}
 
-{% block fullwidth_title %}<h1>Extension</h1>{% endblock %}
+{% block fullwidth_title %}<h1>Features</h1>{% endblock %}
 
 {% block hero_header_inner %}
 <div class="large-12 columns">
   <div class="annotation">
     Apache Solr MCP Server<sup>&trade;</sup> {{ SOLR_MCP_LATEST_RELEASE }}
   </div>
-  <h1>
-    Solr MCP Server Features
-  </h1>
+  <h1>Powerful MCP Tools for Solr</h1>
   <p>
-  The Solr MCP Server is a Model Context Protocol (MCP) server that provides a declarative API for managing Solr Clouds.
+    A comprehensive set of AI-ready tools to search, index, and manage your Solr collections. Designed to work seamlessly with Claude and other LLM assistants through the Model Context Protocol.
   </p>
-  <div class="down-arrow"><a data-scroll href="#crds"><i class="fa fa-angle-down fa-2x red"></i></a></div>
+  <div class="down-arrow"><a data-scroll href="#search-tools"><i class="fa fa-angle-down fa-2x red"></i></a></div>
 </div>
 {% endblock %}
 
 {% block content_inner %}
-<section class="gray col-4 offset-small" id="crds">
+<section class="gray col-4 offset-small" id="search-tools">
   <div class="row">
-    <ul class="small-block-grid-1 medium-block-grid-3">
-      <li>
-          <div class="box">
-            <a href="#solr-mcp">
-            <div class="img"><img src="{{ SITEURL }}/theme/images/Solr_Icons_fast_near_real-time.svg"/></div>
-            <div class="content">
-              <h3>Super</h3>
-              <p>MCP is super</p>
-            </div>
-            </a>
-          </div>
-      </li>
+    <div class="large-10 large-offset-1 columns">
+      <div class="annotation">
+        Search Capabilities
+      </div>
+      <h1>Advanced Search Tools</h1>
+      <p>Execute complex searches with filters, faceting, and pagination—all driven by natural language instructions.</p>
+    </div>
+  </div>
+  <div class="row">
+    <ul class="small-block-grid-1 medium-block-grid-2 large-block-grid-3">
       <li>
         <div class="box">
-        <a href="#solr-metrics">
-            <div class="img"><img src="{{ SITEURL }}/theme/images/Solr_Icons_monitorable_logging.svg"/></div>
-            <div class="content">
-              <h3>Duper</h3>
-              <p>Must find icons for these</p>
-            </div>
-        </a>
+          <div class="img"><img src="{{ SITEURL }}/theme/images/Solr_Icons_advanced_full-text_search.svg"/></div>
+          <div class="content">
+            <h3>Full-Text Search</h3>
+            <p>Execute complex search queries across your collections with support for boolean operators and phrase queries</p>
+          </div>
         </div>
       </li>
       <li>
-        <a href="#solr-backup">
-          <div class="box">
-            <div class="img"><img src="{{ SITEURL }}/theme/images/Solr_Icons_multiple_search_indices.svg"/></div>
-            <div class="content">
-              <h3>Standards based</h3>
-              <p>Yea</p>
-            </div>
+        <div class="box">
+          <div class="img"><img src="{{ SITEURL }}/theme/images/Solr_Icons_flexible_and_adaptable.svg"/></div>
+          <div class="content">
+            <h3>Flexible Filtering</h3>
+            <p>Filter results by field values with support for ranges, wildcards, and complex filter queries</p>
           </div>
-        </a>
+        </div>
+      </li>
+      <li>
+        <div class="box">
+          <div class="img"><img src="{{ SITEURL }}/theme/images/Solr_Icons_monitorable_logging.svg"/></div>
+          <div class="content">
+            <h3>Faceted Search</h3>
+            <p>Get faceted counts across dimensions to power AI-driven analytics and categorization</p>
+          </div>
+        </div>
       </li>
     </ul>
   </div>
 </section>
 
-<section class="hero alternate" id="solr-mcp">
+<section class="gray col-4 offset-small" id="indexing-tools">
   <div class="row">
-    <div class="large-12 columns">
+    <div class="large-10 large-offset-1 columns">
       <div class="annotation">
-        Really super MCP server
+        Indexing & Data Management
       </div>
-      <h1>
-        AI all the way
-      </h1>
-      <div class="down-arrow"><a data-scroll href="#solr-mcp-features"><i class="fa fa-angle-down fa-2x red"></i></a></div>
+      <h1>Flexible Document Indexing</h1>
+      <p>Index documents in multiple formats with automatic field normalization and error handling.</p>
     </div>
   </div>
-</section>
-
-<section class="gray col-4 offset-small" id="solr-mcp-features">
   <div class="row">
-    <ul class="small-block-grid-1 medium-block-grid-3">
+    <ul class="small-block-grid-1 medium-block-grid-2 large-block-grid-3">
       <li>
-        <a href="https://github.com/apache/solr-mcp/blob/main/dev-docs/ARCHITECTURE.md" target="_blank">
-          <div class="box">
-            <div class="img"><img src="{{ SITEURL }}/theme/images/Solr_Icons_standards_based_open_interfaces.svg"/></div>
-            <div class="content">
-              <h3>Modern architecture</h3>
-              <p>The Solr MCP Server is built on Spring AI and complies with latest standards</p>
-            </div>
+        <div class="box">
+          <div class="img"><img src="{{ SITEURL }}/theme/images/Solr_Icons_json,_xml.svg"/></div>
+          <div class="content">
+            <h3>Multi-Format Support</h3>
+            <p>Index documents in JSON, CSV, or XML formats with automatic parsing and validation</p>
           </div>
-        </a>
+        </div>
+      </li>
+      <li>
+        <div class="box">
+          <div class="img"><img src="{{ SITEURL }}/theme/images/Solr_Icons_highly_configurable.svg"/></div>
+          <div class="content">
+            <h3>Field Normalization</h3>
+            <p>Automatically sanitize and normalize field names to match Solr's schema requirements</p>
+          </div>
+        </div>
+      </li>
+      <li>
+        <div class="box">
+          <div class="img"><img src="{{ SITEURL }}/theme/images/Solr_Icons_rich_document.svg"/></div>
+          <div class="content">
+            <h3>Nested Structure Support</h3>
+            <p>Handle complex nested documents and multi-valued fields with intelligent flattening</p>
+          </div>
+        </div>
       </li>
     </ul>
   </div>
 </section>
-  
 
-<section class="gray col-4 offset-small" id="solr-backup-features">
+<section class="gray col-4 offset-small" id="collection-tools">
   <div class="row">
-    <ul class="small-block-grid-1 medium-block-grid-3">
+    <div class="large-10 large-offset-1 columns">
+      <div class="annotation">
+        Collection & Schema Management
+      </div>
+      <h1>Collection Intelligence</h1>
+      <p>Introspect and understand your collections and schemas dynamically within your AI workflows.</p>
+    </div>
+  </div>
+  <div class="row">
+    <ul class="small-block-grid-1 medium-block-grid-2 large-block-grid-3">
       <li>
-        <a href="https://github.com/apache/solr-mcp/" target="_blank">
-          <div class="box">
-            <div class="img"><img src="{{ SITEURL }}/theme/images/Solr_Icons_an_ajax_based.svg"/></div>
-            <div class="content">
-              <h3>Access control</h3>
-              <p>Easily control what the server is </p>
-            </div>
+        <div class="box">
+          <div class="img"><img src="{{ SITEURL }}/theme/images/Solr_Icons_multiple_search_indices.svg"/></div>
+          <div class="content">
+            <h3>Collection Discovery</h3>
+            <p>List and inspect all available collections in your Solr instance</p>
           </div>
-        </a>
+        </div>
+      </li>
+      <li>
+        <div class="box">
+          <div class="img"><img src="{{ SITEURL }}/theme/images/Solr_Icons_highy_scalable.svg"/></div>
+          <div class="content">
+            <h3>Schema Introspection</h3>
+            <p>Dynamically discover field types, analyzers, and schema configuration for intelligent indexing</p>
+          </div>
+        </div>
+      </li>
+      <li>
+        <div class="box">
+          <div class="img"><img src="{{ SITEURL }}/theme/images/Solr_Icons_powerful_extensions.svg"/></div>
+          <div class="content">
+            <h3>Field Metadata</h3>
+            <p>Access detailed field information including type, analysis chains, and configuration</p>
+          </div>
+        </div>
+      </li>
+    </ul>
+  </div>
+</section>
+
+<section class="gray col-4 offset-small" id="platform-tools">
+  <div class="row">
+    <div class="large-10 large-offset-1 columns">
+      <div class="annotation">
+        Platform & Integration
+      </div>
+      <h1>Built for Enterprise Deployment</h1>
+      <p>Deploy with confidence using proven Spring Boot technologies and comprehensive error handling.</p>
+    </div>
+  </div>
+  <div class="row">
+    <ul class="small-block-grid-1 medium-block-grid-2 large-block-grid-3">
+      <li>
+        <div class="box">
+          <div class="img"><img src="{{ SITEURL }}/theme/images/Solr_Icons_standards_based_open_interfaces.svg"/></div>
+          <div class="content">
+            <h3>Standards Compliance</h3>
+            <p>Full implementation of the Model Context Protocol specification for AI assistant integration</p>
+          </div>
+        </div>
+      </li>
+      <li>
+        <div class="box">
+          <div class="img"><img src="{{ SITEURL }}/theme/images/Solr_Icons_an_ajax_based.svg"/></div>
+          <div class="content">
+            <h3>Multiple Transports</h3>
+            <p>Run in STDIO mode for Claude Desktop or HTTP mode for remote deployments and testing</p>
+          </div>
+        </div>
+      </li>
+      <li>
+        <div class="box">
+          <div class="img"><img src="{{ SITEURL }}/theme/images/Solr_Icons_security.svg"/></div>
+          <div class="content">
+            <h3>Error Handling</h3>
+            <p>Comprehensive error reporting and validation ensures clear feedback to AI assistants</p>
+          </div>
+        </div>
       </li>
     </ul>
   </div>

--- a/themes/solr/templates/mcp/features.html
+++ b/themes/solr/templates/mcp/features.html
@@ -1,0 +1,113 @@
+{% extends "mcp/fullwidth.html" %}
+
+{% block fullwidth_title %}<h1>Extension</h1>{% endblock %}
+
+{% block hero_header_inner %}
+<div class="large-12 columns">
+  <div class="annotation">
+    Apache Solr MCP Server<sup>&trade;</sup> {{ SOLR_MCP_LATEST_RELEASE }}
+  </div>
+  <h1>
+    Solr MCP Server Features
+  </h1>
+  <p>
+  The Solr MCP Server is a Model Context Protocol (MCP) server that provides a declarative API for managing Solr Clouds.
+  </p>
+  <div class="down-arrow"><a data-scroll href="#crds"><i class="fa fa-angle-down fa-2x red"></i></a></div>
+</div>
+{% endblock %}
+
+{% block content_inner %}
+<section class="gray col-4 offset-small" id="crds">
+  <div class="row">
+    <ul class="small-block-grid-1 medium-block-grid-3">
+      <li>
+          <div class="box">
+            <a href="#solr-mcp">
+            <div class="img"><img src="{{ SITEURL }}/theme/images/Solr_Icons_fast_near_real-time.svg"/></div>
+            <div class="content">
+              <h3>Super</h3>
+              <p>MCP is super</p>
+            </div>
+            </a>
+          </div>
+      </li>
+      <li>
+        <div class="box">
+        <a href="#solr-metrics">
+            <div class="img"><img src="{{ SITEURL }}/theme/images/Solr_Icons_monitorable_logging.svg"/></div>
+            <div class="content">
+              <h3>Duper</h3>
+              <p>Must find icons for these</p>
+            </div>
+        </a>
+        </div>
+      </li>
+      <li>
+        <a href="#solr-backup">
+          <div class="box">
+            <div class="img"><img src="{{ SITEURL }}/theme/images/Solr_Icons_multiple_search_indices.svg"/></div>
+            <div class="content">
+              <h3>Standards based</h3>
+              <p>Yea</p>
+            </div>
+          </div>
+        </a>
+      </li>
+    </ul>
+  </div>
+</section>
+
+<section class="hero alternate" id="solr-mcp">
+  <div class="row">
+    <div class="large-12 columns">
+      <div class="annotation">
+        Really super MCP server
+      </div>
+      <h1>
+        AI all the way
+      </h1>
+      <div class="down-arrow"><a data-scroll href="#solr-mcp-features"><i class="fa fa-angle-down fa-2x red"></i></a></div>
+    </div>
+  </div>
+</section>
+
+<section class="gray col-4 offset-small" id="solr-mcp-features">
+  <div class="row">
+    <ul class="small-block-grid-1 medium-block-grid-3">
+      <li>
+        <a href="https://github.com/apache/solr-mcp/blob/main/dev-docs/ARCHITECTURE.md" target="_blank">
+          <div class="box">
+            <div class="img"><img src="{{ SITEURL }}/theme/images/Solr_Icons_standards_based_open_interfaces.svg"/></div>
+            <div class="content">
+              <h3>Modern architecture</h3>
+              <p>The Solr MCP Server is built on Spring AI and complies with latest standards</p>
+            </div>
+          </div>
+        </a>
+      </li>
+    </ul>
+  </div>
+</section>
+  
+
+<section class="gray col-4 offset-small" id="solr-backup-features">
+  <div class="row">
+    <ul class="small-block-grid-1 medium-block-grid-3">
+      <li>
+        <a href="https://github.com/apache/solr-mcp/" target="_blank">
+          <div class="box">
+            <div class="img"><img src="{{ SITEURL }}/theme/images/Solr_Icons_an_ajax_based.svg"/></div>
+            <div class="content">
+              <h3>Access control</h3>
+              <p>Easily control what the server is </p>
+            </div>
+          </div>
+        </a>
+      </li>
+    </ul>
+  </div>
+</section>
+
+{{ super() }}
+{% endblock content_inner %}

--- a/themes/solr/templates/mcp/fullwidth.html
+++ b/themes/solr/templates/mcp/fullwidth.html
@@ -1,0 +1,24 @@
+{% extends "mcp/base.html" %}
+
+{% block hero_header %}
+<section class="hero alternate">
+  <div class="row">
+    {% block hero_header_inner %}
+    <div class="large-10 large-offset-1 columns">
+      <div class="annotation">
+        Apache Solr MCP Server<sup>&trade;</sup> {{ SOLR_MCP_LATEST_RELEASE }}
+      </div>
+      <h1>
+        The Apache Solr MCP Server gives your LLM super powers in managing Solr clusters.
+      </h1>
+
+      <div class="down-arrow"><a class="smooth-scroll" href="#learn-more" target="_self"><i class="fa fa-angle-down fa-2x red"></i></a></div>
+    </div>
+    {% endblock hero_header_inner %}
+  </div>
+</section>
+{% endblock hero_header %}
+
+{% block content %}
+{% block content_inner %}{{ page.content }}{% endblock %}
+{% endblock %}

--- a/themes/solr/templates/mcp/index.html
+++ b/themes/solr/templates/mcp/index.html
@@ -19,28 +19,112 @@
 {% block content_inner %}
 <section class="gray offset-medium" id="learn-more"></section>
 
+<section class="orange">
+  <div class="row">
+    <div class="large-10 large-offset-1 columns">
+      <div class="annotation">
+        Apache Solr MCP Server
+      </div>
+      <h1>Give AI Assistants Solr Superpowers</h1>
+      <p>
+        A standards-compliant Model Context Protocol server that brings powerful search, indexing, and collection management capabilities to Claude and other LLM assistants. Built with Spring AI, backed by SolrJ, and ready to deploy anywhere.
+      </p>
+      <div style="margin-top: 30px;">
+        <a href="https://github.com/apache/solr-mcp" target="_blank" class="button">Get Started on GitHub</a>
+      </div>
+    </div>
+  </div>
+</section>
+
 <section class="gray col-4">
   <div class="row">
     <div class="large-10 large-offset-1 columns">
       <div class="annotation">
-        &nbsp;
+        Why Use Solr MCP Server?
       </div>
-      <h1>
-        Learn more about the Solr MCP Server.
-      </h1>
+      <h1>Empower Your AI with Enterprise Search</h1>
       <p>
-      Solr MCP Server gives your LLM Solr superpowers.
+        Integrate Apache Solr directly into your AI workflows. Execute complex searches, manage indexes, and analyze your data—all through natural language with an AI assistant.
       </p>
     </div>
   </div>
   <div class="row">
-    <ul class="small-block-grid-1 medium-block-grid-2 large-block-grid-4">
+    <ul class="small-block-grid-1 medium-block-grid-2 large-block-grid-3">
+      <li>
+        <div class="box">
+          <div class="img"><img src="{{ SITEURL }}/theme/images/Solr_Icons_advanced_full-text_search.svg"/></div>
+          <div class="title">
+            <h3>Powerful Search</h3>
+          </div>
+          <p>Complex queries, filtering, faceting, and pagination through a natural language interface</p>
+        </div>
+      </li>
+      <li>
+        <div class="box">
+          <div class="img"><img src="{{ SITEURL }}/theme/images/Solr_Icons_json,_xml.svg"/></div>
+          <div class="title">
+            <h3>Flexible Indexing</h3>
+          </div>
+          <p>Index documents in JSON, CSV, or XML formats with automatic field name normalization</p>
+        </div>
+      </li>
+      <li>
+        <div class="box">
+          <div class="img"><img src="{{ SITEURL }}/theme/images/Solr_Icons_standards_based_open_interfaces.svg"/></div>
+          <div class="title">
+            <h3>Standards-Based</h3>
+          </div>
+          <p>Implements the Model Context Protocol specification for seamless AI integration</p>
+        </div>
+      </li>
+      <li>
+        <div class="box">
+          <div class="img"><img src="{{ SITEURL }}/theme/images/Solr_Icons_multiple_search_indices.svg"/></div>
+          <div class="title">
+            <h3>Multi-Collection</h3>
+          </div>
+          <p>Manage and query multiple Solr collections and schemas through a unified interface</p>
+        </div>
+      </li>
+      <li>
+        <div class="box">
+          <div class="img"><img src="{{ SITEURL }}/theme/images/Solr_Icons_extensible_plugin.svg"/></div>
+          <div class="title">
+            <h3>Easy Deployment</h3>
+          </div>
+          <p>Deploy as a Docker container, Spring Boot application, or via HTTP/STDIO transports</p>
+        </div>
+      </li>
+      <li>
+        <div class="box">
+          <div class="img"><img src="{{ SITEURL }}/theme/images/Solr_Icons_security.svg"/></div>
+          <div class="title">
+            <h3>Enterprise Ready</h3>
+          </div>
+          <p>Built on proven technologies with comprehensive error handling and logging</p>
+        </div>
+      </li>
+    </ul>
+  </div>
+</section>
+
+<section class="gray col-4">
+  <div class="row">
+    <div class="large-10 large-offset-1 columns">
+      <div class="annotation">
+        Next Steps
+      </div>
+      <h1>Explore the Solr MCP Server</h1>
+    </div>
+  </div>
+  <div class="row">
+    <ul class="small-block-grid-1 medium-block-grid-2">
       <li>
         <a href="/mcp/features.html"><div class="box"><div class="img"><img src="{{ SITEURL }}/theme/images/icon-features.svg"/></div>
             <div class="title">
               <h3>Features</h3>
             </div>
-            <p>What is included?</p>
+            <p>Discover all the capabilities and tools available</p>
             <span class="btn1">Learn More</span>
           </div></a>
       </li>
@@ -49,9 +133,9 @@
           <div class="box">
             <div class="img"><img src="{{ SITEURL }}/theme/images/icon-community.svg"/></div>
             <div class="title">
-              <h3>Solr MCP Server Community</h3>
+              <h3>Community</h3>
             </div>
-            <p>Get support and give back. Contribute to the Solr MCP Server project.</p>
+            <p>Get support, contribute, and join the conversation</p>
             <span class="btn1">Learn More</span>
           </div>
         </a>

--- a/themes/solr/templates/mcp/index.html
+++ b/themes/solr/templates/mcp/index.html
@@ -1,0 +1,79 @@
+{% extends "mcp/fullwidth.html" %}
+
+{% block bodyclass %}homepage{% endblock %}
+
+{% block solr_security_warning %}
+{% set latest_sec_articles = (articles | selectattr("category.name", "eq", "solr/security") | list)[:1] %}
+{% if (latest_sec_articles | length) > 0 %}
+{% set latest_sec_date = latest_sec_articles[0].date | strftime("%Y-%m-%d") %}
+<section class="security" latest-date="{{ latest_sec_date }}">
+  <div class="row">
+    <div class="large-12 columns text-center">
+      <h2><a href="/security.html">&#x26A0; There are recent security announcements. Read more on the Solr Security page.</a></h2>
+    </div>
+  </div>
+</section>
+{% endif %}
+{% endblock %}
+
+{% block content_inner %}
+<section class="gray offset-medium" id="learn-more"></section>
+
+<section class="gray col-4">
+  <div class="row">
+    <div class="large-10 large-offset-1 columns">
+      <div class="annotation">
+        &nbsp;
+      </div>
+      <h1>
+        Learn more about the Solr MCP Server.
+      </h1>
+      <p>
+      Solr MCP Server gives your LLM Solr superpowers.
+      </p>
+    </div>
+  </div>
+  <div class="row">
+    <ul class="small-block-grid-1 medium-block-grid-2 large-block-grid-4">
+      <li>
+        <a href="/mcp/features.html"><div class="box"><div class="img"><img src="{{ SITEURL }}/theme/images/icon-features.svg"/></div>
+            <div class="title">
+              <h3>Features</h3>
+            </div>
+            <p>What is included?</p>
+            <span class="btn1">Learn More</span>
+          </div></a>
+      </li>
+      <li>
+        <a href="/mcp/community.html">
+          <div class="box">
+            <div class="img"><img src="{{ SITEURL }}/theme/images/icon-community.svg"/></div>
+            <div class="title">
+              <h3>Solr MCP Server Community</h3>
+            </div>
+            <p>Get support and give back. Contribute to the Solr MCP Server project.</p>
+            <span class="btn1">Learn More</span>
+          </div>
+        </a>
+      </li>
+    </ul>
+  </div>
+</section>
+  
+<section class="white">
+  <div class="row">
+    <div class="large-12 columns text-center">
+      <h1>
+        The Apache Software Foundation
+      </h1>
+      <p>
+        The Apache Software Foundation provides support for the Apache community of open-source software projects. The Apache projects are defined by collaborative consensus based processes, an open, pragmatic software license and a desire to create high quality software that leads the way in its field. Apache Lucene, Apache Solr, Apache PyLucene, Apache Open Relevance Project and their respective logos are trademarks of The Apache Software Foundation. All other marks mentioned may be trademarks or registered trademarks of their respective owners.
+      </p>
+      <hr/>
+      <p>
+        <a class="acevent" data-format="wide" data-mode="light" data-width="480"></a>
+      </p>
+    </div>
+  </div>
+</section>
+{% endblock content_inner %}

--- a/themes/solr/templates/mcp/page.html
+++ b/themes/solr/templates/mcp/page.html
@@ -1,0 +1,11 @@
+{% extends "mcp/base.html" %}
+
+{% block content %}
+<div class="container">
+  {% block subnav %}
+  {% endblock %}
+  <div class="row">
+    {% block content_inner %}{{ page.content }}{% endblock %}
+  </div>
+</div>
+{% endblock %}

--- a/themes/solr/templates/mcp/subnav.html
+++ b/themes/solr/templates/mcp/subnav.html
@@ -1,0 +1,20 @@
+{% extends "mcp/page.html" %}
+
+{% block subnav %}
+<div class="row">
+  <div class="small-12 text-center columns">
+    <h1>{% block subnav_title %}{% endblock %}<br/>
+      <small>{% block subnav_subtitle %}{% endblock %}</small></h1>
+  </div>
+</div>
+<div class="sub-nav-container">
+  <div class="row sub-nav-border anchor-top">
+    <div class="small-12 text-center columns">
+      <dl class="sub-nav">
+        {% block subnav_nav_items %}
+        {% endblock %}
+      </dl>
+    </div>
+  </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
First shot at a MCP subproject website for Solr. I picked a green theme at random to distinguish from the red and lilac we already have, could be any color really. Preliminary content filled by GenAI.

PR includes DOAP file, which can be linked into the [master DOAP catalog](https://svn.apache.org/repos/asf/comdev/projects.apache.org/trunk/data/projects.xml) for ASF and thus make the sub project show up in phonebook, ATR etc.

@adityamparikh see README for this solr-site repo for how to spin up the website based on a git checkout.

<img width="1025" height="772" alt="Skjermbilde 2025-11-17 kl  19 29 42" src="https://github.com/user-attachments/assets/a6eb6573-ab18-4573-9fad-c7829fe291fa" />

https://issues.apache.org/jira/browse/SOLR-17992