### PR TITLE
Common Posts page

### DIFF
--- a/content/pages/news.md
+++ b/content/pages/news.md
@@ -3,4 +3,4 @@ URL: news.html
 save_as: news.html
 template: news
 
-You may also read these news as an [ATOM feed](/feeds/solr/news.atom.xml).
+You may also read these news as ATOM feeds: [Announcements](/feeds/solr/news.atom.xml), [Security Announcements](/feeds/solr/security.atom.xml)..

--- a/content/pages/posts.md
+++ b/content/pages/posts.md
@@ -1,0 +1,4 @@
+Title: Posts
+URL: posts.html
+save_as: posts.html
+template: posts

--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -97,9 +97,13 @@ PLUGINS = [
     'jinja2content',
     'regex_replace',
     'age_days_lt',
-    'vex'
+    'vex',
+    'combined_posts',
 #    'md_inline_extension',
 ]
+
+# Configuration for combined posts pagination
+COMBINED_POSTS_PER_PAGE = 20
 
 MARKDOWN = {
     'extension_configs': {

--- a/plugins/combined_posts/__init__.py
+++ b/plugins/combined_posts/__init__.py
@@ -1,0 +1,110 @@
+"""
+Pelican plugin to generate a combined posts page with pagination.
+
+Combines articles (solr/news, solr/security) with pages (solr/blogposts),
+sorts them chronologically, and generates paginated output.
+"""
+
+from pelican import signals
+from pelican.generators import Generator
+from pelican.paginator import Paginator
+from pelican.writers import Writer
+import os
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class CombinedPostsGenerator(Generator):
+    """
+    Generator for creating a combined posts page with pagination.
+
+    Combines articles from 'solr/news' and 'solr/security' categories
+    with pages from 'solr/blogposts' category, sorts chronologically,
+    and generates paginated HTML pages.
+    """
+
+    def generate_output(self, writer):
+        """Generate paginated combined posts pages."""
+
+        # Get all articles and pages
+        articles = self.context.get('articles', [])
+        pages = self.context.get('pages', [])
+
+        # Filter and combine
+        # Include articles from news and security categories
+        combined_articles = [
+            a for a in articles
+            if hasattr(a, 'category') and a.category and
+               a.category.name in ['solr/news', 'solr/security']
+        ]
+
+        # Include pages from blogposts category
+        combined_pages = [
+            p for p in pages
+            if hasattr(p, 'category') and p.category and
+               p.category.name == 'solr/blogposts'
+        ]
+
+        # Combine all
+        combined_posts = combined_articles + combined_pages
+
+        # Sort by date, newest first
+        combined_posts.sort(key=lambda x: x.date, reverse=True)
+
+        # Get pagination settings
+        per_page = self.settings.get('COMBINED_POSTS_PER_PAGE', 20)
+
+        # Create paginator
+        paginator = Paginator('posts', 'posts{number}.html',
+                              combined_posts, self.settings, per_page)
+
+        # Get the template
+        template = self.get_template('posts')
+
+        # Generate each page
+        for page_num in range(1, paginator.num_pages + 1):
+            posts_page = paginator.page(page_num)
+
+            # Build context
+            context = self.context.copy()
+            context.update({
+                'posts': posts_page.object_list,
+                'posts_page': posts_page,
+                'posts_paginator': paginator,
+                'page': posts_page,  # For breadcrumb/metadata
+                'title': 'Posts',
+                'slug': 'posts',
+            })
+
+            # Determine output path
+            if page_num == 1:
+                output_path = os.path.join(self.output_path, 'posts.html')
+                url = 'posts.html'
+            else:
+                output_path = os.path.join(
+                    self.output_path,
+                    f'posts{page_num}.html'
+                )
+                url = f'posts{page_num}.html'
+
+            # Ensure output directory exists
+            os.makedirs(os.path.dirname(output_path), exist_ok=True)
+
+            # Render and write
+            output = template.render(context)
+            with open(output_path, 'w', encoding='utf-8') as f:
+                f.write(output)
+
+            # Log
+            logger.info(f'Writing {url} ({page_num}/{paginator.num_pages})')
+
+
+def get_generators(pelican):
+    """Register the CombinedPostsGenerator."""
+    return CombinedPostsGenerator
+
+
+def register():
+    """Plugin registration hook."""
+    signals.get_generators.connect(get_generators)

--- a/themes/solr/static/css/base.css
+++ b/themes/solr/static/css/base.css
@@ -1032,6 +1032,77 @@ ul li div.box div.img.logo-container.orange-background {
   background-color:#D9411E;
 }
 .full-width .gray .box.logo-box {
-  position: relative; 
+  position: relative;
   border: 1px solid #CCC;
+}
+
+/*
+ * Posts Page Styles
+ */
+.posts-filter {
+  margin-bottom: 30px;
+  padding-bottom: 20px;
+  border-bottom: 1px solid #e4e2dd;
+}
+
+.posts-filter a {
+  margin-right: 20px;
+  text-transform: uppercase;
+  font-size: 0.9em;
+  font-weight: 500;
+}
+
+.posts-filter a.active {
+  color: #2d7a3e;
+  font-weight: bold;
+}
+
+.post-item-title {
+  color: #D9411E;
+}
+
+.post-item-title a {
+  color: #D9411E;
+  text-decoration: none;
+}
+
+.post-item-title a:hover {
+  text-decoration: underline;
+}
+
+.read-more {
+  margin-top: 10px;
+  font-size: 0.9em;
+}
+
+.read-more a {
+  color: #D9411E;
+  font-weight: 600;
+}
+
+/*
+ * Posts Page Pagination
+ */
+.pagination {
+  margin-top: 40px;
+  padding-top: 20px;
+  border-top: 1px solid #e4e2dd;
+  text-align: center;
+}
+
+.pagination a {
+  margin: 0 10px;
+  color: #D9411E;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.pagination a:hover {
+  text-decoration: underline;
+}
+
+.pagination-info {
+  margin: 10px 0;
+  font-size: 0.95em;
+  color: #555;
 }

--- a/themes/solr/static/css/base.css
+++ b/themes/solr/static/css/base.css
@@ -835,6 +835,11 @@ section.list ul li ul li {
   z-index: 2000;
 }
 
+.sub-nav dd a.selected {
+  color: #2d7a3e;
+  font-weight: bold;
+}
+
 .codehilite {
   margin: 10px 0;
   background-color: #EEEEEE;
@@ -1036,26 +1041,6 @@ ul li div.box div.img.logo-container.orange-background {
   border: 1px solid #CCC;
 }
 
-/*
- * Posts Page Styles
- */
-.posts-filter {
-  margin-bottom: 30px;
-  padding-bottom: 20px;
-  border-bottom: 1px solid #e4e2dd;
-}
-
-.posts-filter a {
-  margin-right: 20px;
-  text-transform: uppercase;
-  font-size: 0.9em;
-  font-weight: 500;
-}
-
-.posts-filter a.active {
-  color: #2d7a3e;
-  font-weight: bold;
-}
 
 .post-item-title {
   color: #D9411E;

--- a/themes/solr/static/javascript/main.js
+++ b/themes/solr/static/javascript/main.js
@@ -101,7 +101,13 @@
           scope.$watch(function() { return window.location.pathname }, function(n, o, s) {
             scope.model.path = window.location.pathname
             $(el).find('a').removeClass('selected')
-            $(el).find('a[href="' + scope.model.path + '"]').addClass('selected')
+            var path = scope.model.path
+            var newsPages = ['/news.html', '/blog.html']
+            if (newsPages.indexOf(path) !== -1) {
+              $(el).find('a[href$="/posts.html"]').addClass('selected')
+            } else {
+              $(el).find('a[href="' + path + '"]').addClass('selected')
+            }
           })
 
         }

--- a/themes/solr/templates/_header.html
+++ b/themes/solr/templates/_header.html
@@ -11,10 +11,7 @@
       <div class="top-bar-section">
         <ul class="navigation right">
           <li>
-            <a href="{{ SITEURL }}/blog.html">Blog</a>
-          </li>
-          <li>
-            <a href="{{ SITEURL }}/news.html">News</a>
+            <a href="{{ SITEURL }}/posts.html">Posts</a>
           </li>
           <li>
             <a href="{{ SITEURL }}/security.html">Security</a>

--- a/themes/solr/templates/_header.html
+++ b/themes/solr/templates/_header.html
@@ -11,7 +11,7 @@
       <div class="top-bar-section">
         <ul class="navigation right">
           <li>
-            <a href="{{ SITEURL }}/posts.html">Posts</a>
+            <a href="{{ SITEURL }}/posts.html">News</a>
           </li>
           <li>
             <a href="{{ SITEURL }}/security.html">Security</a>

--- a/themes/solr/templates/bloghome.html
+++ b/themes/solr/templates/bloghome.html
@@ -17,7 +17,16 @@
       padding-top: 70px;
       margin-top: -70px;
     }
+    .breadcrumb {
+      margin-bottom: 20px;
+      font-size: 0.9em;
+    }
   </style>
+
+  <div class="breadcrumb">
+    <a href="{{ SITEURL }}/posts.html">← Back to All Posts</a>
+  </div>
+
   <h1 id="solr-blogs">Solr<sup>™</sup> Blog Posts<a class="headerlink" href="#solr-blog-posts" title="Permanent link">¶</a></h1>
   {{page.content}}
 

--- a/themes/solr/templates/bloghome.html
+++ b/themes/solr/templates/bloghome.html
@@ -1,4 +1,11 @@
-{% extends "page.html" %}
+{% extends "subnav.html" %}
+
+{% block subnav_header %}<style>.container { padding-top: 0; }</style>{% endblock %}
+{% block subnav_nav_items %}
+<dd><a href="{{ SITEURL }}/posts.html">All News</a></dd>
+<dd><a href="{{ SITEURL }}/blog.html" class="selected">Blog</a></dd>
+<dd><a href="{{ SITEURL }}/news.html">Announcements</a></dd>
+{% endblock %}
 
 {% block ng_directives %}x-ng-app-root="/solr"{% endblock %}
 
@@ -17,15 +24,7 @@
       padding-top: 70px;
       margin-top: -70px;
     }
-    .breadcrumb {
-      margin-bottom: 20px;
-      font-size: 0.9em;
-    }
   </style>
-
-  <div class="breadcrumb">
-    <a href="{{ SITEURL }}/posts.html">← Back to All News</a>
-  </div>
 
   <h1 id="solr-blogs">Solr<sup>™</sup> Blog Posts<a class="headerlink" href="#solr-blog-posts" title="Permanent link">¶</a></h1>
   {{page.content}}

--- a/themes/solr/templates/bloghome.html
+++ b/themes/solr/templates/bloghome.html
@@ -24,7 +24,7 @@
   </style>
 
   <div class="breadcrumb">
-    <a href="{{ SITEURL }}/posts.html">← Back to All Posts</a>
+    <a href="{{ SITEURL }}/posts.html">← Back to All News</a>
   </div>
 
   <h1 id="solr-blogs">Solr<sup>™</sup> Blog Posts<a class="headerlink" href="#solr-blog-posts" title="Permanent link">¶</a></h1>

--- a/themes/solr/templates/news.html
+++ b/themes/solr/templates/news.html
@@ -18,7 +18,16 @@
       padding-top: 70px;
       margin-top: -70px;
     }
+    .breadcrumb {
+      margin-bottom: 20px;
+      font-size: 0.9em;
+    }
   </style>
+
+  <div class="breadcrumb">
+    <a href="{{ SITEURL }}/posts.html">← Back to All Posts</a>
+  </div>
+
   <h1 id="solr-news">Solr<sup>™</sup> News<a class="headerlink" href="#solr-news" title="Permanent link">¶</a></h1>
   {{page.content}}
 

--- a/themes/solr/templates/news.html
+++ b/themes/solr/templates/news.html
@@ -25,10 +25,10 @@
   </style>
 
   <div class="breadcrumb">
-    <a href="{{ SITEURL }}/posts.html">← Back to All Posts</a>
+    <a href="{{ SITEURL }}/posts.html">← Back to All News</a>
   </div>
 
-  <h1 id="solr-news">Solr<sup>™</sup> News<a class="headerlink" href="#solr-news" title="Permanent link">¶</a></h1>
+  <h1 id="solr-news">Solr<sup>™</sup> Announcements<a class="headerlink" href="#solr-news" title="Permanent link">¶</a></h1>
   {{page.content}}
 
   {% for article in (articles | selectattr("category.name", "in", ['solr/news', 'solr/security'])|list) %}

--- a/themes/solr/templates/news.html
+++ b/themes/solr/templates/news.html
@@ -1,4 +1,11 @@
-{% extends "page.html" %}
+{% extends "subnav.html" %}
+
+{% block subnav_header %}<style>.container { padding-top: 0; }</style>{% endblock %}
+{% block subnav_nav_items %}
+<dd><a href="{{ SITEURL }}/posts.html">All News</a></dd>
+<dd><a href="{{ SITEURL }}/blog.html">Blog</a></dd>
+<dd><a href="{{ SITEURL }}/news.html" class="selected">Announcements</a></dd>
+{% endblock %}
 
 {% block ng_directives %}x-ng-app-root="/solr"{% endblock %}
 {% block rss %}<link rel="alternate" type="application/atom+xml" title="Solr news except security news" href="/feeds/solr/news.atom.xml" />{% endblock %}
@@ -18,15 +25,7 @@
       padding-top: 70px;
       margin-top: -70px;
     }
-    .breadcrumb {
-      margin-bottom: 20px;
-      font-size: 0.9em;
-    }
   </style>
-
-  <div class="breadcrumb">
-    <a href="{{ SITEURL }}/posts.html">← Back to All News</a>
-  </div>
 
   <h1 id="solr-news">Solr<sup>™</sup> Announcements<a class="headerlink" href="#solr-news" title="Permanent link">¶</a></h1>
   {{page.content}}

--- a/themes/solr/templates/posts.html
+++ b/themes/solr/templates/posts.html
@@ -1,0 +1,65 @@
+{% extends "page.html" %}
+
+{% block ng_directives %}x-ng-app-root="/solr"{% endblock %}
+{% block rss %}<link rel="alternate" type="application/atom+xml" title="Solr news except security news" href="/feeds/solr/news.atom.xml" />{% endblock %}
+
+{% block content_inner %}
+<div class="small-12 columns">
+
+
+  <h1 id="solr-posts">Solr<sup>™</sup> Posts<a class="headerlink" href="#solr-posts" title="Permanent link">¶</a></h1>
+  {{page.content}}
+
+  <div class="posts-filter">
+    <strong>View:</strong>
+    <a href="{{ SITEURL }}/posts.html" class="active">All Posts</a>
+    <a href="{{ SITEURL }}/blog.html">Blog</a>
+    <a href="{{ SITEURL }}/news.html">News</a>
+  </div>
+
+  {% for article in posts %}
+    <h2 id="{{ article.slug }}" class="post-item-title">
+      {% if article.save_as %}
+        {# Blog post - has its own page #}
+        <a href="{{ article.url }}">{{ article.title }}</a>
+      {% else %}
+        {# News/Security article - link to news.html with anchor #}
+        <a href="{{ SITEURL }}/news.html#{{ article.slug }}">{{ article.title }}</a>
+      {% endif %}
+      <a class="headerlink" href="#{{ article.slug }}" title="Permanent link">¶</a>
+    </h2>
+    <h5>
+      {% if article.category and article.category.name in ['solr/news', 'solr/security'] %}
+        <strong>{{ article.category.name | replace('solr/', '') | title }}:</strong>
+      {% endif %}
+      {{ article.locale_date }}
+    </h5>
+    {% if article.summary %}
+      <p>{{ article.summary | striptags | truncate(512) }}</p>
+    {% else %}
+      <p>{{ article.content | striptags | truncate(512) }}</p>
+    {% endif %}
+    {% if article.category and article.category.name in ['solr/news', 'solr/security'] %}
+      <div class="read-more">
+        <a href="{{ SITEURL }}/news.html#{{ article.slug }}">Read full article on news page →</a>
+      </div>
+    {% endif %}
+    <hr/>
+  {% endfor %}
+
+  {% if posts_paginator and posts_paginator.num_pages > 1 %}
+  <div class="pagination">
+    {% if posts_page.has_previous() %}
+      <a href="{{ SITEURL }}/{% if posts_page.previous_page_number() == 1 %}posts.html{% else %}posts{{ posts_page.previous_page_number() }}.html{% endif %}">← Previous</a>
+    {% endif %}
+    <span class="pagination-info">
+      Page {{ posts_page.number }} of {{ posts_paginator.num_pages }}
+    </span>
+    {% if posts_page.has_next() %}
+      <a href="{{ SITEURL }}/posts{{ posts_page.next_page_number() }}.html">Next →</a>
+    {% endif %}
+  </div>
+  {% endif %}
+
+</div>
+{% endblock content_inner %}

--- a/themes/solr/templates/posts.html
+++ b/themes/solr/templates/posts.html
@@ -1,4 +1,11 @@
-{% extends "page.html" %}
+{% extends "subnav.html" %}
+
+{% block subnav_title %}Solr™ News{% endblock %}
+{% block subnav_nav_items %}
+<dd><a href="{{ SITEURL }}/posts.html" class="selected">All News</a></dd>
+<dd><a href="{{ SITEURL }}/blog.html">Blog</a></dd>
+<dd><a href="{{ SITEURL }}/news.html">Announcements</a></dd>
+{% endblock %}
 
 {% block ng_directives %}x-ng-app-root="/solr"{% endblock %}
 {% block rss %}<link rel="alternate" type="application/atom+xml" title="Solr news except security news" href="/feeds/solr/news.atom.xml" />{% endblock %}
@@ -24,15 +31,7 @@
     }
   </style>
 
-  <h1 id="solr-posts">Solr<sup>™</sup> News<a class="headerlink" href="#solr-posts" title="Permanent link">¶</a></h1>
   {{page.content}}
-
-  <div class="posts-filter">
-    <strong>View:</strong>
-    <a href="{{ SITEURL }}/posts.html" class="active">All News</a>
-    <a href="{{ SITEURL }}/blog.html">Blog</a>
-    <a href="{{ SITEURL }}/news.html">Announcements</a>
-  </div>
 
   {% for article in posts %}
     <h2 id="{{ article.slug }}" class="post-item-title">

--- a/themes/solr/templates/posts.html
+++ b/themes/solr/templates/posts.html
@@ -6,15 +6,32 @@
 {% block content_inner %}
 <div class="small-12 columns">
 
+  <style type="text/css">
+    .headerlink, .elementid-permalink {
+      visibility: hidden;
+    }
+    h2:hover > .headerlink, h3:hover > .headerlink, h1:hover > .headerlink, h6:hover > .headerlink, h4:hover > .headerlink, h5:hover > .headerlink, dt:hover > .elementid-permalink {
+      visibility: visible;
+    }
+    h2 {
+      /* Avoid news title being hidden behind header when linked by anchor link */
+      padding-top: 70px;
+      margin-top: -70px;
+    }
+    .breadcrumb {
+      margin-bottom: 20px;
+      font-size: 0.9em;
+    }
+  </style>
 
-  <h1 id="solr-posts">Solr<sup>™</sup> Posts<a class="headerlink" href="#solr-posts" title="Permanent link">¶</a></h1>
+  <h1 id="solr-posts">Solr<sup>™</sup> News<a class="headerlink" href="#solr-posts" title="Permanent link">¶</a></h1>
   {{page.content}}
 
   <div class="posts-filter">
     <strong>View:</strong>
-    <a href="{{ SITEURL }}/posts.html" class="active">All Posts</a>
+    <a href="{{ SITEURL }}/posts.html" class="active">All News</a>
     <a href="{{ SITEURL }}/blog.html">Blog</a>
-    <a href="{{ SITEURL }}/news.html">News</a>
+    <a href="{{ SITEURL }}/news.html">Announcements</a>
   </div>
 
   {% for article in posts %}

--- a/themes/solr/templates/subnav.html
+++ b/themes/solr/templates/subnav.html
@@ -1,12 +1,14 @@
 {% extends "page.html" %}
 
 {% block subnav %}
+{% block subnav_header %}
 <div class="row">
   <div class="small-12 text-center columns">
     <h1>{% block subnav_title %}{% endblock %}<br/>
       <small>{% block subnav_subtitle %}{% endblock %}</small></h1>
   </div>
 </div>
+{% endblock %}
 <div class="sub-nav-container">
   <div class="row sub-nav-border anchor-top">
     <div class="small-12 text-center columns">


### PR DESCRIPTION
Introduce a common "Posts" page that lists all News, Security-news and Blog posts chronologically.

The page will be the only one linked in the header menu.
It will have links to (existing) news.html and blog.html on the top.
Clicking a title on the posts list will bring you to the existing location of the post/blog, so no broken links.
The posts page has pagination.

New page:
<img width="1011" height="622" alt="Skjermbilde 2025-11-18 kl  08 53 40" src="https://github.com/user-attachments/assets/bdacc965-ff87-420f-b8af-2d4418d8f5b8" />
Existing blog page (with a back link):
<img width="1010" height="661" alt="Skjermbilde 2025-11-18 kl  08 53 53" src="https://github.com/user-attachments/assets/a609b7cb-fe8f-42af-9897-de657f862c24" />
Existing news page (with a back link):
<img width="995" height="697" alt="Skjermbilde 2025-11-18 kl  08 54 05" src="https://github.com/user-attachments/assets/0cc3585e-bbda-4a23-ab66-731a12dae6fc" />
