### PR TITLE
Fix bloghome template broken by Pelican 4.12.0

### DIFF
--- a/themes/solr/templates/bloghome.html
+++ b/themes/solr/templates/bloghome.html
@@ -14,7 +14,7 @@
 
   <hr/>
 
-  {% for article in (pages | selectattr("category.name", "in", ["solr/blogposts"]) |list | sort(attribute="date") | reverse) %}
+  {% for article in (pages | selectattr("category", "equalto", "solr/blogposts") |list | sort(attribute="date") | reverse) %}
   <h2 id="{{ article.slug }}">
     <a href="{{article.url}}">
       {{ article.title }}


### PR DESCRIPTION
Page objects don't have a Category object like Articles do — their category metadata is stored as a plain string. Using selectattr on "category.name" worked accidentally before but Pelican 4.12.0 (#177) raises a Jinja2 UndefinedError. Switch to comparing the category string directly with "equalto".