### PR TITLE
Add comparison harness link to Solr/Lucene migration post

### DIFF
--- a/content/pages/blogposts/2026-05-02-solr-lucene-migration-correctness.md
+++ b/content/pages/blogposts/2026-05-02-solr-lucene-migration-correctness.md
@@ -10,3 +10,4 @@ save_as: blogposts/solr-lucene-migration-correctness.html
 Major Solr/Lucene upgrades can introduce subtle ranking behavior changes even when functional tests continue to pass. This article discusses a practical side-by-side validation approach for detecting candidate-set changes, rank deltas, score distribution drift, and latency differences during migration testing.
 
 The complete post can be read here: [Validating Ranking Correctness During Solr/Lucene Migrations](https://dzone.com/articles/solr5-to-solr8-migration-ads-system).
+A companion comparison harness and detailed checklist are available at [solr-lucene-migration-correctness](https://github.com/parveensaini/solr-lucene-migration-correctness).


### PR DESCRIPTION
## Summary

This PR adds a companion GitHub comparison harness/checklist link to the Solr/Lucene migration correctness blog post entry.

The post currently links to the external article. This update adds the related open-source harness that demonstrates the side-by-side comparison approach discussed in the article.

## Related context

This follows a review comment on PR #178 suggesting that the comparison tool and detailed checklist should also be linked.

## Link added

[https://github.com/parveensaini/solr-lucene-migration-correctness](https://github.com/parveensaini/solr-lucene-migration-correctness?utm_source=chatgpt.com)