### PR TITLE
List every VEX file on the CVE Dependencies along with their status

### DIFF
--- a/plugins/vex/vex.py
+++ b/plugins/vex/vex.py
@@ -158,8 +158,7 @@ def pelican_init(pelicanobj):
 
 
 def generator_initialized(generator):
-    # The CVE table (security-dependency-cves.html) lists every VEX entry,
-    # regardless of state or whether it names vulnerable JARs.
+    # The CVE table (security-dependency-cves.html) lists every VEX entry.
     generator.context["vex"] = read_vex_articles(generator.settings['PATH'])
 
 

--- a/plugins/vex/vex.py
+++ b/plugins/vex/vex.py
@@ -158,10 +158,9 @@ def pelican_init(pelicanobj):
 
 
 def generator_initialized(generator):
-    # The dependency-CVE table (security-dependency-cves.html) lists the entries
-    # that name vulnerable JARs; advisory-only entries (no 'jars') are excluded.
-    articles = read_vex_articles(generator.settings['PATH'])
-    generator.context["vex"] = [a for a in articles if a['jars']]
+    # The CVE table (security-dependency-cves.html) lists every VEX entry,
+    # regardless of state or whether it names vulnerable JARs.
+    generator.context["vex"] = read_vex_articles(generator.settings['PATH'])
 
 
 def set_vex_slug(content):

--- a/plugins/vex/vex.py
+++ b/plugins/vex/vex.py
@@ -158,8 +158,11 @@ def pelican_init(pelicanobj):
 
 
 def generator_initialized(generator):
-    # The CVE table (security-dependency-cves.html) lists every VEX entry.
-    generator.context["vex"] = read_vex_articles(generator.settings['PATH'])
+    # The dependency-CVE table (security-dependency-cves.html) lists the entries
+    # that declare vulnerable JARs, in all states (including exploitable).
+    # Advisory-only entries without 'jars' (e.g. Solr-native CVEs) are excluded.
+    articles = read_vex_articles(generator.settings['PATH'])
+    generator.context["vex"] = [a for a in articles if a['jars']]
 
 
 def set_vex_slug(content):

--- a/themes/solr/templates/security-dependency-cves.html
+++ b/themes/solr/templates/security-dependency-cves.html
@@ -16,8 +16,8 @@
   </div>
 
   <h2 id="cve-table">CVE Status for Dependencies <a class="headerlink" href="#cve-table" title="Permanent link">¶</a></h2>
-  <p>Below is a list of CVE vulnerabilities in Apache Solr dependencies and their applicability to Solr.
-     CVEs assessed as exploitable in Solr have their own advisory on the
+  <p>Below is a list of CVE vulnerabilities in Apache Solr dependencies and their applicability to Solr,
+     with the assessed state of each. CVEs assessed as exploitable in Solr also have their own advisory on the
      <a href="{{ SITEURL }}/security-news.html">security news page</a>.</p>
 
   <table>
@@ -29,7 +29,7 @@
       <th>Title</th>
     </tr>
     {# vex is in ascending filename (date) order; reverse for newest first #}
-    {% for v in (vex | reverse | selectattr("analysis.state", "ne", "exploitable")) %}
+    {% for v in (vex | reverse) %}
     <tr>
       <td>
         {% for id in v.ids %}
@@ -43,7 +43,7 @@
           {{ jar }}{% if not loop.last %}, {% endif %}
         {% endfor %}
       </td>
-      <td>{{ v.analysis.state.replace('_', ' ') }}</td>
+      <td><span class="cdx-{{ v.analysis.state|replace('_', '-') }}">{{ v.analysis.state.replace('_', ' ') }}</span></td>
       <td><a href="/vex.html#{{ v.anchor }}">{{ v.title }}</a></td>
     </tr>
     {% endfor %}


### PR DESCRIPTION
Turns out there are dependencies that have CVE's that are exploitable in Solr according to the VEX standard, that don't have a Solr specific CVE, or show up in that listing.   

This changes the table to showing all VEX entries, regardless of state (exploitable or not), and displays that information as a label:

<img width="995" height="695" alt="image" src="https://github.com/user-attachments/assets/b8e64df6-f01e-440a-97ca-4bc620d3e4f6" />

Notice the first two items, they are issues with OpenNLP in Solr 9 branch that I am creating new vex entries for and will open a seperate PR.