### PR TITLE
SOLR-18288: VEX statements for the April 2026 Apache Log4j CVEs

### DIFF
--- a/content/solr/vex/2026-04-10-cve-2026-34477.md
+++ b/content/solr/vex/2026-04-10-cve-2026-34477.md
@@ -2,7 +2,7 @@
 cve: CVE-2026-34477
 category:
   - solr/vex
-versions: "9.10.1"
+versions: "9.10.1, 10.0.0"
 jars:
   - log4j-core-2.25.3.jar
 analysis:

--- a/content/solr/vex/2026-04-10-cve-2026-34477.md
+++ b/content/solr/vex/2026-04-10-cve-2026-34477.md
@@ -1,0 +1,43 @@
+---
+cve: CVE-2026-34477
+category:
+  - solr/vex
+versions: "9.10.1"
+jars:
+  - log4j-core-2.25.3.jar
+analysis:
+  state: not_affected
+  justification: requires_configuration
+title: "Apache Log4j Core: TLS hostname verification silently ignored in Socket, SMTP and Syslog appenders"
+---
+CVE-2026-34477 is **not** considered exploitable in typical deployments of Apache Solr.
+Successful exploitation requires a specific, non-default logging configuration together with a privileged network position.
+The following conditions **must all be met**:
+
+* The Log4j configuration is modified to add an `SMTP`, `Socket` or `Syslog` appender that ships logs over TLS through a nested `<Ssl>` element.
+* That appender relies on the `verifyHostName` attribute to authenticate the remote receiver, which was silently ignored through Log4j Core 2.25.3.
+* A man-in-the-middle attacker can intercept the connection and present a certificate issued by a CA trusted by the configured (or default) trust store.
+
+None of the Log4j configuration files shipped in the Solr 9.10.1 binary distribution define such an appender.
+They only use `Console` and `RollingRandomAccessFile` appenders, which open no network connection,
+so no TLS hostname verification ever takes place.
+The `HTTP` appender is not affected either, as it uses a separate `verifyHostname` attribute that verifies host names by default.
+
+A configuration that does meet the conditions above looks like this:
+
+```xml
+<Appenders>
+  <Socket name="remote" host="logs.example.com" port="6514">
+    <!-- verifyHostName="true" was silently ignored through 2.25.3 -->
+    <Ssl verifyHostName="true">
+      <KeyStore location="..." password="..."/>
+      <TrustStore location="..." password="..."/>
+    </Ssl>
+    <PatternLayout pattern="%m%n"/>
+  </Socket>
+</Appenders>
+```
+
+Operators who do configure TLS network appenders should replace the vulnerable JAR file
+(`server/lib/ext/log4j-core-2.25.3.jar`)
+with `log4j-core-2.25.4.jar`.

--- a/content/solr/vex/2026-04-10-cve-2026-34477.md
+++ b/content/solr/vex/2026-04-10-cve-2026-34477.md
@@ -1,5 +1,6 @@
 ---
 cve: CVE-2026-34477
+jira: SOLR-18288
 category:
   - solr/vex
 versions: "9.10.1, 10.0.0"

--- a/content/solr/vex/2026-04-10-cve-2026-34478.md
+++ b/content/solr/vex/2026-04-10-cve-2026-34478.md
@@ -2,7 +2,7 @@
 cve: CVE-2026-34478
 category:
   - solr/vex
-versions: "9.10.1"
+versions: "9.10.1, 10.0.0"
 jars:
   - log4j-core-2.25.3.jar
 analysis:

--- a/content/solr/vex/2026-04-10-cve-2026-34478.md
+++ b/content/solr/vex/2026-04-10-cve-2026-34478.md
@@ -1,0 +1,44 @@
+---
+cve: CVE-2026-34478
+category:
+  - solr/vex
+versions: "9.10.1"
+jars:
+  - log4j-core-2.25.3.jar
+analysis:
+  state: not_affected
+  justification: requires_configuration
+title: "Apache Log4j Core: Log injection via CRLF sequences in Rfc5424Layout"
+---
+CVE-2026-34478 is **not** considered exploitable in typical deployments of Apache Solr.
+Successful exploitation requires a specific, non-default logging configuration.
+The following conditions **must all be met**:
+
+* The Log4j configuration is modified to send logs to a stream-based (TCP or TLS) syslog service using `Rfc5424Layout` directly.
+* An attacker is able to inject CRLF sequences into the logged data.
+
+Because the `newLineEscape` and `useTlsMessageFormat` attributes were silently renamed in Log4j Core 2.21.0,
+newline escaping stopped working and TLS framing was downgraded to plain TCP,
+leaving such configurations exposed to CRLF log injection.
+
+None of the Log4j configuration files shipped in the Solr 9.10.1 binary distribution reference `Rfc5424Layout`.
+They only use `PatternLayout`, so the issue cannot be triggered.
+Users of the `Syslog` appender are not affected either, since its attributes were not renamed.
+
+A configuration that does meet the conditions above looks like this:
+
+```xml
+<Appenders>
+  <Socket name="syslog" host="logs.example.com" port="601" protocol="TCP">
+    <Rfc5424Layout appName="Solr" newLineEscape="\\n"/>
+  </Socket>
+</Appenders>
+```
+
+Operators who do configure `Rfc5424Layout` should either:
+
+* replace `newLineEscape` with `escapeNL` and `useTlsMessageFormat` with `useTLSMessageFormat`
+  (note the capitalization), or
+* replace the vulnerable JAR file
+  (`server/lib/ext/log4j-core-2.25.3.jar`)
+  with `log4j-core-2.25.4.jar`.

--- a/content/solr/vex/2026-04-10-cve-2026-34478.md
+++ b/content/solr/vex/2026-04-10-cve-2026-34478.md
@@ -1,5 +1,6 @@
 ---
 cve: CVE-2026-34478
+jira: SOLR-18288
 category:
   - solr/vex
 versions: "9.10.1, 10.0.0"

--- a/content/solr/vex/2026-04-10-cve-2026-34479.md
+++ b/content/solr/vex/2026-04-10-cve-2026-34479.md
@@ -2,7 +2,7 @@
 cve: CVE-2026-34479
 category:
   - solr/vex
-versions: "9.10.1"
+versions: "9.10.1, 10.0.0"
 jars:
   - log4j-1.2-api-2.25.3.jar
 analysis:

--- a/content/solr/vex/2026-04-10-cve-2026-34479.md
+++ b/content/solr/vex/2026-04-10-cve-2026-34479.md
@@ -1,5 +1,6 @@
 ---
 cve: CVE-2026-34479
+jira: SOLR-18288
 category:
   - solr/vex
 versions: "9.10.1, 10.0.0"

--- a/content/solr/vex/2026-04-10-cve-2026-34479.md
+++ b/content/solr/vex/2026-04-10-cve-2026-34479.md
@@ -1,0 +1,41 @@
+---
+cve: CVE-2026-34479
+category:
+  - solr/vex
+versions: "9.10.1"
+jars:
+  - log4j-1.2-api-2.25.3.jar
+analysis:
+  state: not_affected
+  justification: requires_configuration
+title: "Apache Log4j 1.x bridge: Malformed XML output from Log4j1XmlLayout"
+---
+CVE-2026-34479 is **not** considered exploitable in typical deployments of Apache Solr.
+Successful exploitation requires a specific, non-default logging configuration.
+The following conditions **must all be met**:
+
+* The Log4j 1-to-Log4j 2 bridge emits logs through `Log4j1XmlLayout`,
+  either configured directly in a Log4j 2 configuration
+  or selected as `org.apache.log4j.xml.XMLLayout` through the Log4j 1 compatibility layer.
+* The logged data contains characters forbidden by the XML 1.0 specification.
+
+The `log4j-1.2-api` JAR is shipped so that third-party libraries that still call the Log4j 1 API keep working.
+However, Solr is configured through Log4j 2 configuration files that only use `PatternLayout`,
+and the distribution ships no Log4j 1 (`log4j.properties` or `log4j.xml`) configuration file,
+so the vulnerable layout is never instantiated.
+
+A configuration that does meet the conditions above looks like this:
+
+```xml
+<Appenders>
+  <File name="xml" fileName="${sys:solr.log.dir}/solr-events.xml">
+    <Log4j1XmlLayout/>
+  </File>
+</Appenders>
+```
+
+Operators who use legacy Log4j 1 configuration files or `Log4j1XmlLayout` should replace the vulnerable JAR file
+(`server/lib/ext/log4j-1.2-api-2.25.3.jar`)
+with `log4j-1.2-api-2.25.4.jar`.
+Support for `Log4j1XmlLayout` and legacy Log4j 1 configuration files may be removed in a future Solr release,
+so migrating to a native Log4j 2 configuration is recommended.

--- a/content/solr/vex/2026-04-10-cve-2026-34480.md
+++ b/content/solr/vex/2026-04-10-cve-2026-34480.md
@@ -2,7 +2,7 @@
 cve: CVE-2026-34480
 category:
   - solr/vex
-versions: "9.10.1"
+versions: "9.10.1, 10.0.0"
 jars:
   - log4j-core-2.25.3.jar
 analysis:

--- a/content/solr/vex/2026-04-10-cve-2026-34480.md
+++ b/content/solr/vex/2026-04-10-cve-2026-34480.md
@@ -1,0 +1,40 @@
+---
+cve: CVE-2026-34480
+category:
+  - solr/vex
+versions: "9.10.1"
+jars:
+  - log4j-core-2.25.3.jar
+analysis:
+  state: not_affected
+  justification: requires_configuration
+title: "Apache Log4j Core: Invalid XML output from XmlLayout"
+---
+CVE-2026-34480 is **not** considered exploitable in typical deployments of Apache Solr.
+Successful exploitation requires a specific, non-default logging configuration.
+The following conditions **must all be met**:
+
+* The Log4j configuration is modified to write events through `XmlLayout`.
+* A log message or MDC value contains characters forbidden by the XML 1.0 specification.
+
+When triggered, the layout produces malformed XML, which downstream log processors may reject:
+silently with the JRE built-in StAX, or by dropping the event with alternative implementations such as Woodstox.
+
+None of the Log4j configuration files shipped in the Solr 9.10.1 binary distribution reference `XmlLayout`.
+They only use `PatternLayout`, so the vulnerable code path is never reached.
+The MDC values that Solr populates (collection, shard, replica, core and node names, plus a trace id) are not emitted as XML either.
+
+A configuration that does meet the conditions above looks like this:
+
+```xml
+<Appenders>
+  <RollingFile name="xml" fileName="${sys:solr.log.dir}/solr-events.xml"
+               filePattern="${sys:solr.log.dir}/solr-events.xml.%i">
+    <XmlLayout/>
+  </RollingFile>
+</Appenders>
+```
+
+Operators who do configure `XmlLayout` should replace the vulnerable JAR file
+(`server/lib/ext/log4j-core-2.25.3.jar`)
+with `log4j-core-2.25.4.jar`.

--- a/content/solr/vex/2026-04-10-cve-2026-34480.md
+++ b/content/solr/vex/2026-04-10-cve-2026-34480.md
@@ -1,5 +1,6 @@
 ---
 cve: CVE-2026-34480
+jira: SOLR-18288
 category:
   - solr/vex
 versions: "9.10.1, 10.0.0"

--- a/content/solr/vex/2026-04-10-cve-2026-34481.md
+++ b/content/solr/vex/2026-04-10-cve-2026-34481.md
@@ -2,7 +2,7 @@
 cve: CVE-2026-34481
 category:
   - solr/vex
-versions: "9.10.1"
+versions: "9.10.1, 10.0.0"
 jars:
   - log4j-layout-template-json-2.25.3.jar
 analysis:

--- a/content/solr/vex/2026-04-10-cve-2026-34481.md
+++ b/content/solr/vex/2026-04-10-cve-2026-34481.md
@@ -1,0 +1,26 @@
+---
+cve: CVE-2026-34481
+category:
+  - solr/vex
+versions: "9.10.1"
+jars:
+  - log4j-layout-template-json-2.25.3.jar
+analysis:
+  state: not_affected
+  justification: code_not_reachable
+title: "Apache Log4j JSON Template Layout: Invalid JSON for non-finite floating-point values"
+---
+CVE-2026-34481 is **not** considered exploitable in any deployment of the Apache Solr binary distribution.
+Successful exploitation requires the application to log a `MapMessage` (or one of its subclasses)
+carrying a non-finite floating-point value (`NaN`, `Infinity` or `-Infinity`) through `JsonTemplateLayout`,
+which the layout then serializes as invalid JSON, in breach of RFC 8259.
+
+Producing a `MapMessage` requires application code, and users of the binary distribution run only the code shipped by Apache Solr.
+A scan of the bytecode of all 486 JAR files in the distribution confirms that the `MapMessage` family
+(`MapMessage`, `StringMapMessage`, `ObjectMapMessage` and `StructuredDataMessage`)
+is referenced only inside Log4j's own JARs.
+Neither Solr nor any of its bundled dependencies ever constructs or logs such a message.
+
+Because no shipped code can hand a triggering value to the layout,
+the vulnerable code path cannot be reached regardless of the configured layout,
+and the Solr community considers this vulnerability **non-exploitable** in the binary distribution.

--- a/content/solr/vex/2026-04-10-cve-2026-34481.md
+++ b/content/solr/vex/2026-04-10-cve-2026-34481.md
@@ -1,5 +1,6 @@
 ---
 cve: CVE-2026-34481
+jira: SOLR-18288
 category:
   - solr/vex
 versions: "9.10.1, 10.0.0"

--- a/content/solr/vex/2026-04-10-cve-2026-34481.md
+++ b/content/solr/vex/2026-04-10-cve-2026-34481.md
@@ -16,8 +16,8 @@ carrying a non-finite floating-point value (`NaN`, `Infinity` or `-Infinity`) th
 which the layout then serializes as invalid JSON, in breach of RFC 8259.
 
 Producing a `MapMessage` requires application code, and users of the binary distribution run only the code shipped by Apache Solr.
-A scan of the bytecode of all 486 JAR files in the distribution confirms that the `MapMessage` family
-(`MapMessage`, `StringMapMessage`, `ObjectMapMessage` and `StructuredDataMessage`)
+A scan of the bytecode of all JAR files in the distribution confirms that the `MapMessage` family
+(`MapMessage`, `StringMapMessage` and `StructuredDataMessage`)
 is referenced only inside Log4j's own JARs.
 Neither Solr nor any of its bundled dependencies ever constructs or logs such a message.
 


### PR DESCRIPTION
You broke it, you fix it. Since we (the Log4j team) decided to pollute the world with these CVEs, the least we can do is help evaluate their (negligible) impact on Apache Solr.

This adds VEX statements for the five April 2026 Apache Log4j CVEs, assessed against the **Solr 9.10.1** binary distribution:

| CVE | Component | Verdict |
| --- | --- | --- |
| CVE-2026-34477 | log4j-core | not_affected / requires_configuration |
| CVE-2026-34478 | log4j-core | not_affected / requires_configuration |
| CVE-2026-34479 | log4j-1.2-api | not_affected / requires_configuration |
| CVE-2026-34480 | log4j-core | not_affected / requires_configuration |
| CVE-2026-34481 | log4j-layout-template-json | not_affected / code_not_reachable |

**TL;DR: none of these are reachable in a stock Solr install.**

* 34477-34480 all require swapping Solr's default `PatternLayout` for some exotic layout or appender (`XmlLayout`, `Rfc5424Layout`, the Log4j 1 bridge, or a TLS network appender). If you didn't go out of your way to do that, you are fine.
* 34481 needs someone to log a `MapMessage` with a `NaN`/`Infinity` float through `JsonTemplateLayout`. A scan of all 486 jars in the distribution shows nothing ever produces a `MapMessage`, so it is simply unreachable.

Each statement spells out the exact configuration that would make you vulnerable, and which jar in `server/lib/ext/` to swap if you really did go off-piste.

Solves SOLR-18288.
