### PR TITLE
VEX statements for CVEs affecting Jetty 10 in Solr 9

### DIFF
--- a/content/solr/vex/2026-06-18-cve-2025-11143.md
+++ b/content/solr/vex/2026-06-18-cve-2025-11143.md
@@ -6,10 +6,8 @@ versions: "≤ 9.x"
 jars:
   - jetty-http-10.0.26.jar
 analysis:
-  state: exploitable
-  response:
-    - update
-    - workaround_available
+  state: not_affected
+  justification: requires_configuration
 title: "Eclipse Jetty: differential URI parsing can bypass front-end URI controls"
 ---
 CVE-2025-11143 (CVSS 6.5; 3.7 per the Eclipse Foundation) is an improper-input-validation issue
@@ -20,31 +18,30 @@ path allow/deny lists) or to reveal implementation details. It affects Jetty 9.4
 10.0.0–10.0.26, 11.0.0–11.0.26, 12.0.0–12.0.30 and 12.1.0–12.1.4; it is fixed in 9.4.59, 10.0.27,
 11.0.27, 12.0.31 and 12.1.5.
 
-Like the HTTP/1.1 parser, this is **core request-parsing code**, not an optional Jetty module. Solr
-embeds Jetty as its HTTP server and bundles the vulnerable `jetty-http` module (`HttpURI`) —
-`jetty-http-10.0.26.jar` in the Solr 9.x line, and Jetty 9.4.44 in earlier 9.x releases — and does
-not replace Jetty's URI parser, so the vulnerable code parses every request URI and the code path is
-reachable.
+CVE-2025-11143 is **not** considered exploitable in production deployments of Apache Solr.
+Successful exploitation requires a specific, non-recommended configuration — all of the following
+conditions must be true:
 
-#### Exploitability depends on a fronting proxy
+* Solr must be deployed behind an HTTP intermediary (reverse proxy, load balancer, or API gateway)
+  that enforces **URI-based** access rules (for example, blocking `/solr/admin/*` at the proxy layer).
+* That intermediary must be the **sole** security gate — Solr's own **authentication and
+  authorization must not be enabled**.
 
-This is a **differential-parsing** issue: it only has security impact when a second HTTP component in
-front of Jetty parses a crafted URI differently and makes an access-control decision on it. It is
-therefore only exploitable when Solr is deployed **behind an HTTP intermediary** — a reverse proxy,
-load balancer, or API gateway — that enforces **URI-based** access rules (for example, allowing
-`/solr/<collection>/select` while blocking `/solr/admin/*`). A malformed URI can be parsed one way by
-the proxy (and allowed) and another way by Jetty/Solr (reaching a blocked path). A Solr instance that
-is **not** fronted by such a proxy, or whose proxy does not make URI-based access decisions, is not
-meaningfully exposed to this issue.
+#### Why Solr auth is a complete fix
 
-#### Mitigation
+This is a **differential-parsing** issue: it only has security impact when a front-end proxy makes an
+access-control decision based on its own URI interpretation and Solr has no independent access control
+of its own. Solr enforces access control in its own servlet filter (`SolrDispatchFilter` /
+the `AuthenticationPlugin` framework) **after** Jetty has parsed the URI. Because Solr's auth layer
+operates on the same already-resolved path that Jetty produced, it cannot be confused by differential
+proxy/Jetty parsing — the bypass that the proxy grants does not help an attacker get past Solr's own
+auth. Enabling Solr auth provides **complete** protection, not merely a mitigating control. (This
+distinguishes CVE-2025-11143 from request-smuggling issues such as CVE-2026-2332, where Solr auth
+reduces impact but does not eliminate all cross-connection effects.)
 
-* **Enable Solr's built-in authentication and authorization.** Solr enforces access control in its
-  own servlet filter (`SolrDispatchFilter` / the `AuthenticationPlugin` framework) after Jetty has
-  parsed the URI, so protection does not depend on the front-end proxy's URI interpretation. Enabling
-  it removes the "proxy is the only gate" exposure that makes this bypass useful.
-* **Upgrade the bundled Jetty** to a patched release (≥ 10.0.27 on the 10.0.x line) for the full fix,
-  however that requires commercial support, as Jetty 10.x is end-of-life. See
-  https://webtide.com/end-of-life/. 
+The Apache Solr project considers authentication and authorization a prerequisite for any
+production-secure deployment and explicitly warns against relying on network-perimeter controls as the
+sole access mechanism. A deployment without Solr auth that relies on a proxy's URI rules as its only
+security boundary is therefore outside the project's supported production configuration.
 
 Solr 10.0 ships the fixed Jetty 12.0.34.

--- a/content/solr/vex/2026-06-18-cve-2025-11143.md
+++ b/content/solr/vex/2026-06-18-cve-2025-11143.md
@@ -1,0 +1,50 @@
+---
+cve: CVE-2025-11143
+category:
+  - solr/vex
+versions: "≤ 9.x"
+jars:
+  - jetty-http-10.0.26.jar
+analysis:
+  state: exploitable
+  response:
+    - update
+    - workaround_available
+title: "Eclipse Jetty: differential URI parsing can bypass front-end URI controls"
+---
+CVE-2025-11143 (CVSS 6.5; 3.7 per the Eclipse Foundation) is an improper-input-validation issue
+(CWE-20) in Eclipse Jetty's URI parser (`HttpURI`): it interprets some invalid or unusual URIs
+differently from other common HTTP parsers. When a component in front of Jetty parses the same URI
+differently, an attacker can craft a malformed URI to bypass URI-based security controls (such as
+path allow/deny lists) or to reveal implementation details. It affects Jetty 9.4.0–9.4.58,
+10.0.0–10.0.26, 11.0.0–11.0.26, 12.0.0–12.0.30 and 12.1.0–12.1.4; it is fixed in 9.4.59, 10.0.27,
+11.0.27, 12.0.31 and 12.1.5.
+
+Like the HTTP/1.1 parser, this is **core request-parsing code**, not an optional Jetty module. Solr
+embeds Jetty as its HTTP server and bundles the vulnerable `jetty-http` module (`HttpURI`) —
+`jetty-http-10.0.26.jar` in the Solr 9.x line, and Jetty 9.4.44 in earlier 9.x releases — and does
+not replace Jetty's URI parser, so the vulnerable code parses every request URI and the code path is
+reachable.
+
+#### Exploitability depends on a fronting proxy
+
+This is a **differential-parsing** issue: it only has security impact when a second HTTP component in
+front of Jetty parses a crafted URI differently and makes an access-control decision on it. It is
+therefore only exploitable when Solr is deployed **behind an HTTP intermediary** — a reverse proxy,
+load balancer, or API gateway — that enforces **URI-based** access rules (for example, allowing
+`/solr/<collection>/select` while blocking `/solr/admin/*`). A malformed URI can be parsed one way by
+the proxy (and allowed) and another way by Jetty/Solr (reaching a blocked path). A Solr instance that
+is **not** fronted by such a proxy, or whose proxy does not make URI-based access decisions, is not
+meaningfully exposed to this issue.
+
+#### Mitigation
+
+* **Enable Solr's built-in authentication and authorization.** Solr enforces access control in its
+  own servlet filter (`SolrDispatchFilter` / the `AuthenticationPlugin` framework) after Jetty has
+  parsed the URI, so protection does not depend on the front-end proxy's URI interpretation. Enabling
+  it removes the "proxy is the only gate" exposure that makes this bypass useful.
+* **Upgrade the bundled Jetty** to a patched release (≥ 10.0.27 on the 10.0.x line) for the full fix,
+  however that requires commercial support, as Jetty 10.x is end-of-life. See
+  https://webtide.com/end-of-life/. 
+
+Solr 10.0 ships the fixed Jetty 12.0.34.

--- a/content/solr/vex/2026-06-18-cve-2026-2332.md
+++ b/content/solr/vex/2026-06-18-cve-2026-2332.md
@@ -1,0 +1,52 @@
+---
+cve: CVE-2026-2332
+category:
+  - solr/vex
+versions: "≤ 9.x"
+jars:
+  - jetty-http-10.0.26.jar
+analysis:
+  state: exploitable
+  response:
+    - update
+    - workaround_available
+title: "Eclipse Jetty: HTTP/1.1 request smuggling via chunk-extension parsing"
+---
+CVE-2026-2332 (CVSS 9.1) is an HTTP request-smuggling issue (CWE-444) in Eclipse Jetty's HTTP/1.1
+parser: the chunk-extension parser stops at a `\r\n` inside a quoted string instead of treating it
+as an error, so a crafted chunk extension can desynchronize request boundaries between Jetty and a
+front-end HTTP intermediary. It affects Jetty 9.4.0–9.4.59, 10.0.0–10.0.27, 11.0.0–11.0.27,
+12.0.0–12.0.32 and 12.1.0–12.1.6; it is fixed in 9.4.60, 10.0.28, 11.0.28, 12.0.33 and 12.1.7.
+
+Unlike optional Jetty features (for example the JASPI authenticator), this is **core request-parsing
+code**. Solr embeds Jetty as its HTTP server and bundles the vulnerable `jetty-http` module
+(`HttpParser`) — `jetty-http-10.0.26.jar` in the Solr 9.x line, and Jetty 9.4.44 in earlier 9.x
+releases. Solr does not replace Jetty's wire-level HTTP parser, and it accepts chunked request
+bodies, so the vulnerable parser handles incoming requests and the code path is reachable.
+
+#### Exploitability depends on a fronting proxy
+
+Request smuggling is a **desynchronization** attack: it requires a second HTTP processor in front of
+Jetty that parses the crafted chunk extension differently. It is therefore only exploitable when Solr
+is deployed **behind an HTTP intermediary** — a reverse proxy, load balancer, TLS terminator, or API
+gateway — that disagrees with Jetty on request boundaries. This is a common Solr deployment, because
+operators frequently front Solr with such a proxy to add TLS and authentication. A Solr instance that
+is **not** fronted by a mis-parsing intermediary has no second parser to desync against, so this
+particular attack does not apply to it.
+
+The most damaging scenario is when that fronting proxy is the *only* security boundary (it enforces
+authentication or restricts which Solr paths are reachable): a smuggled request rides past the proxy
+and reaches Solr's APIs directly, bypassing those controls.
+
+#### Mitigation
+
+* **Enable Solr's built-in authentication and authorization.** Solr enforces access control in its
+  own servlet filter (`SolrDispatchFilter` / the `AuthenticationPlugin` framework), *not* at the
+  Jetty layer, so a request smuggled past a front-end proxy still has to pass Solr's own
+  authentication and authorization. Enabling them removes the "proxy is the only gate" exposure that
+  makes this attack most severe. (This is a mitigating control, not a complete fix — it does not
+  eliminate cross-connection effects such as request hijacking or response desync.)
+* **Upgrade the bundled Jetty** to a patched release (≥ 10.0.28 on the 10.0.x line), which is the
+  full fix, however that requires a commercial support.  See https://webtide.com/end-of-life/ for options. 
+
+Solr 10.0 ships the fixed Jetty 12.0.34.

--- a/content/solr/vex/2026-06-18-cve-2026-2332.md
+++ b/content/solr/vex/2026-06-18-cve-2026-2332.md
@@ -40,6 +40,14 @@ and reaches Solr's APIs directly, bypassing those controls.
 
 #### Mitigation
 
+* **Use a re-encoding reverse proxy.** A reverse proxy that fully parses and re-encodes the HTTP/1.1
+  request body before forwarding to Jetty eliminates the attack at the network boundary: the proxy
+  reads the attacker's malformed chunk extensions, then emits a clean, standards-conformant chunked
+  (or `Content-Length`) request to Solr. No attacker-controlled chunk extension survives the trip, so
+  Jetty never sees the malformed framing that triggers the desynchronization. **nginx** (`proxy_pass`
+  in HTTP mode) and **HAProxy** (in `http` mode) both re-encode by default. Proxies configured in
+  TCP pass-through or tunnel mode (e.g., HAProxy `tcp` mode, nginx `stream`) do *not* re-encode and
+  do not mitigate this CVE.
 * **Enable Solr's built-in authentication and authorization.** Solr enforces access control in its
   own servlet filter (`SolrDispatchFilter` / the `AuthenticationPlugin` framework), *not* at the
   Jetty layer, so a request smuggled past a front-end proxy still has to pass Solr's own
@@ -47,6 +55,6 @@ and reaches Solr's APIs directly, bypassing those controls.
   makes this attack most severe. (This is a mitigating control, not a complete fix — it does not
   eliminate cross-connection effects such as request hijacking or response desync.)
 * **Upgrade the bundled Jetty** to a patched release (≥ 10.0.28 on the 10.0.x line), which is the
-  full fix, however that requires a commercial support.  See https://webtide.com/end-of-life/ for options. 
+  full fix, however that requires commercial support. See https://webtide.com/end-of-life/ for options.
 
 Solr 10.0 ships the fixed Jetty 12.0.34.

--- a/content/solr/vex/2026-06-18-cve-2026-5795.md
+++ b/content/solr/vex/2026-06-18-cve-2026-5795.md
@@ -1,0 +1,32 @@
+---
+cve: CVE-2026-5795
+category:
+  - solr/vex
+versions: "≤ 9.x"
+jars:
+  - jetty-server-10.0.26.jar
+analysis:
+  state: not_affected
+  justification: code_not_present
+title: "Eclipse Jetty: privilege escalation via uncleared JASPI ThreadLocals"
+---
+CVE-2026-5795 (CVSS 7.4) is a broken-access-control / privilege-escalation issue in Eclipse Jetty's
+`JASPIAuthenticator` (the JSR-196 / Jakarta Authentication "JASPI" integration). During an
+authentication check it sets thread-local state and, on an early return, fails to clear it, so a
+subsequent request served by the same pooled thread can inherit that authentication state. It
+affects Jetty 9.4.0–9.4.60, 10.0.0–10.0.28, 11.0.0–11.0.28, 12.0.0–12.0.33 and 12.1.0–12.1.7; it is
+fixed in 9.4.61, 10.0.29, 11.0.29, 12.0.34 and 12.1.8.
+
+Apache Solr 9.x bundles an affected Jetty (`jetty-server-10.0.26.jar` in the current 9.x line, and
+Jetty 9.4.44 in earlier 9.x releases), so dependency scanners flag this CVE. Solr is **not affected**:
+
+* **The vulnerable code is not shipped.** `JASPIAuthenticator` lives in Jetty's `jetty-jaspi`
+  module. Solr does not depend on `jetty-jaspi` — it is absent from Solr's dependency set (the build
+  pulls in `jetty-server`, `jetty-security`, `jetty-servlet`, etc., but not `jetty-jaspi`), so the
+  vulnerable class is not on the classpath.
+* **Solr does not use JASPI.** Solr authenticates requests in a servlet filter
+  (`SolrDispatchFilter`) through its own `AuthenticationPlugin` framework (Basic, JWT, Kerberos,
+  PKI, etc.). It never installs a Jetty `SecurityHandler`/`Authenticator`, and never the JASPI
+  mechanism, so the vulnerable code path is unreachable even if the module were present.
+
+Solr 10.0 ships the fixed Jetty 12.0.34.


### PR DESCRIPTION
Three CVEs, CVE-2026-5795, CVE-2026-2332, CVE-2025-11143 against Jetty 10 that impact Solr 9.   

[CVE-2026-5795](https://nvd.nist.gov/vuln/detail/CVE-2026-5795) is not an issue for Solr, but the other two https://nvd.nist.gov/vuln/detail/CVE-2026-2332, and [CVE-2026-5795](https://nvd.nist.gov/vuln/detail/CVE-2026-5795) are.



