### PR TITLE
Remove redundant Visual Guide link from resources page

### DIFF
--- a/content/pages/resources.md
+++ b/content/pages/resources.md
@@ -25,8 +25,6 @@ Users who have completed the tutorial are encouraged to review the [other docume
 
 * [Solr Reference Guide](/guide)
 
-* [Visual Guide to Streaming Expressions and Math Expressions](http://bit.ly/32srTpA)
-
 <h3 class="offset" id="javadocs">Solr Javadocs</h3>
 
 Solr generates JavaDocs for all included code in each release.


### PR DESCRIPTION
## Summary
- Removes the bit.ly link to "Visual Guide to Streaming Expressions and Math Expressions", which duplicated the Solr Reference Guide link directly above it and pointed to a dead-link-prone shortener.

## Test plan
- [x] Rendered resources.md diff reviewed; no other content affected.