### PR TITLE
Refine the VEX files to have specific jars and specific begin/end versions

### DIFF
--- a/content/solr/vex/2022-12-14-cve-2021-33813.md
+++ b/content/solr/vex/2022-12-14-cve-2021-33813.md
@@ -2,11 +2,18 @@
 cve: CVE-2021-33813
 category:
   - solr/vex
-versions: "≤ 8.x"
+versions: "3.6.0-8.8.1"
 jars:
-  - jdom-*.jar
+  - jdom-2.0.2.jar
+  - jdom2-2.0.6.jar
 analysis:
   state: not_affected
-title: "jdom-*"
+title: "jdom / jdom2 XXE"
 ---
+CVE-2021-33813 is an XML external entity (XXE) issue in JDOM's `SAXBuilder`, affecting all JDOM
+releases up to and including 2.0.6 (fixed in 2.0.6.1). Solr has bundled JDOM (transitively, via
+Apache Tika / Solr Cell) since Solr 3.6.0 — `jdom` 1.0, then `jdom` 2.0.2, then `jdom2` 2.0.6 —
+through the last 8.x release; Solr 9.0.0 upgraded to the fixed `jdom2` 2.0.6.1. The affected range is
+therefore 3.6.0 – 8.8.1.
+
 JDOM is only used in Solr Cell, which should not be used in production which makes the vulnerability unexploitable. It is a dependency of Apache Tika, which has analyzed the issue and determined the vulnerability is limited to two libraries not commonly used in search applications, see TIKA-3488 for details. Since Tika should be used outside of Solr, use a version of Tika which updates the affected libraries if concerned about exposure to this issue.

--- a/content/solr/vex/2022-12-14-cve-2022-25168.md
+++ b/content/solr/vex/2022-12-14-cve-2022-25168.md
@@ -2,11 +2,17 @@
 cve: CVE-2022-25168
 category:
   - solr/vex
-versions: "≤ 9.0"
+versions: "4.4.0-9.0.0"
 jars:
-  - hadoop-common-3.2.2.jar
+  - hadoop-common-3.3.2.jar
 analysis:
   state: not_affected
 title: "hadoop-common"
 ---
+CVE-2022-25168 is a command-injection flaw in Apache Hadoop's `FileUtil.unTar(...)`, which fails to
+escape the input filename before passing it to a shell. It affects `hadoop-common` 2.0.0–2.10.1,
+3.0.0-alpha–3.2.3 and 3.3.0–3.3.2 (fixed in 2.10.2, 3.2.4 and 3.3.3). Solr has bundled an affected
+`hadoop-common` (transitively, for HDFS support) since Solr 4.4.0, through Solr 9.0.0 (which ships
+3.3.2); Solr 9.1.0 upgraded to the fixed 3.3.4. The affected range is therefore 4.4.0 – 9.0.0.
+
 The vulnerable code won't be used by Solr because Solr only is only using HDFS as a client.

--- a/content/solr/vex/2022-12-14-cve-2022-33980.md
+++ b/content/solr/vex/2022-12-14-cve-2022-33980.md
@@ -2,11 +2,17 @@
 cve: CVE-2022-33980
 category:
   - solr/vex
-versions: "≤ 9.0"
+versions: "9.0.0"
 jars:
   - commons-configuration2-2.7.jar
 analysis:
   state: not_affected
 title: "commons-configuration2"
 ---
+CVE-2022-33980 is a code-execution issue in Apache Commons Configuration: versions 2.4 through 2.7
+performed variable interpolation with `script`, `dns` and `url` lookups enabled by default (fixed in
+2.8.0). Only Solr 9.0.0 shipped an affected version (`commons-configuration2` 2.7); Solr 8.x shipped
+2.1.1 (before the flaw was introduced) and Solr 9.1.0 upgraded to the fixed 2.8.0. The affected
+version is therefore 9.0.0 only.
+
 Solr uses commons-configuration2 for "hadoop-auth" only (for Kerberos). It is only used for loading Hadoop configuration files that would only ever be provided by trusted administrators, not externally (untrusted).

--- a/content/solr/vex/2022-12-14-cve-2022-42889.md
+++ b/content/solr/vex/2022-12-14-cve-2022-42889.md
@@ -2,11 +2,17 @@
 cve: CVE-2022-42889
 category:
   - solr/vex
-versions: "≤ 9.0"
+versions: "8.1.0-9.0.0"
 jars:
-  - commons-text-1.9.jar
+  - commons-text-1.8.jar
 analysis:
   state: not_affected
-title: "commons-text"
+title: "commons-text (Text4Shell)"
 ---
+CVE-2022-42889 ("Text4Shell") is a code-execution issue in Apache Commons Text: from version 1.5
+through 1.9, the default `StringSubstitutor` interpolators included `script`, `dns` and `url`
+lookups that could execute arbitrary code (fixed in 1.10.0). Solr bundled an affected `commons-text`
+in 8.1.0 (1.6) through 9.0.0 (1.8); Solr 8.0.0 shipped 1.4 (before the flaw was introduced) and Solr
+9.1.0 upgraded to the fixed 1.10.0. The affected range is therefore 8.1.0 – 9.0.0.
+
 Solr uses commons-text directly (StringEscapeUtils.escapeEcmaScript) in LoadAdminUiServlet that is not vulnerable. Solr also has a "hadoop-auth" module that uses Apache Hadoop which uses commons-text through commons-configuration2. For Solr, the concern is limited to loading Hadoop configuration files that would only ever be provided by trusted administrators, not externally (untrusted).

--- a/content/solr/vex/2024-01-12-cve-2023-51074.md
+++ b/content/solr/vex/2024-01-12-cve-2023-51074.md
@@ -4,7 +4,7 @@ cve:
   - GHSA-pfh2-hfmq-phg5
 category:
   - solr/vex
-versions: "≤ 9.5"
+versions: "8.1.0-9.5.0"
 jars:
   - json-path-2.8.0.jar
 analysis:
@@ -13,4 +13,6 @@ title: "json-path"
 ---
 The only places we use json-path is for querying (via Calcite) and for transforming/indexing custom JSON. Since the advisory describes a problem that is limited to the current thread, and users that are allowed to query/transform/index are already trusted to cause load to some extent, this advisory does not appear to have impact on the way json-path is used in Solr.
 
-Regardless, Solr upgraded the bundled json-path to 2.9.0 — which fixes CVE-2023-51074 — in Solr 9.6.0, so the vulnerable json-path (≤ 2.8.0) only shipped through Solr 9.5.
+CVE-2023-51074 affects json-path 2.2.0 through 2.8.0 (fixed in 2.9.0). Solr first bundled json-path
+in Solr 8.1.0 (2.4.0) and shipped an affected version — 2.4.0, then 2.7.0, then 2.8.0 — through Solr
+9.5.0; Solr 9.6.0 upgraded to the fixed 2.9.0. The affected range is therefore 8.1.0 – 9.5.0.

--- a/content/solr/vex/2025-01-26-cve-2025-24814.md
+++ b/content/solr/vex/2025-01-26-cve-2025-24814.md
@@ -3,7 +3,7 @@ cve: CVE-2025-24814
 jira: SOLR-16781
 category:
   - solr/vex
-versions: "≤ 9.7"
+versions: "4.8.0-9.7.0"
 analysis:
   state: exploitable
   response:
@@ -20,7 +20,11 @@ Solr instances are vulnerable if they:
 In this configuration, attackers can exploit a privilege escalation issue by replacing individual "trusted" configset files with potentially untrusted files from elsewhere on the filesystem.
 These replacements are incorrectly treated as "trusted" and can leverage `<lib>` tags to add arbitrary code to Solr's classpath, potentially allowing malicious plugins or components to be loaded.
 
-This issue affects all Apache Solr versions up through Solr 9.7.
+This issue affects all Apache Solr versions up through Solr 9.7. The vulnerable behavior lives in
+the filesystem-backed config-set service used in standalone / user-managed mode — named
+`FileSystemConfigSetService` since Solr 9.0.0 (SOLR-15258), but present as its functional predecessor
+`ConfigSetService.Standalone` all the way back to Solr 4.8.0 (SOLR-4478). The affected range is
+therefore 4.8.0 – 9.7.0; Solr 9.8.0 mitigates it by disabling `<lib>` tags by default.
 
 #### Mitigation
 

--- a/content/solr/vex/2025-02-26-cve-2024-6763.md
+++ b/content/solr/vex/2025-02-26-cve-2024-6763.md
@@ -2,11 +2,18 @@
 cve: CVE-2024-6763
 category:
   - solr/vex
-versions: "≤ 9.7"
+versions: "4.0.0-9.10.1"
 jars:
   - jetty-http-10.0.22.jar
 analysis:
   state: not_affected
 title: "jetty-http"
 ---
-Solr does not use the Jetty "HttpURI" utility class necessary for the vulnerability.
+CVE-2024-6763 is an improper-input-validation issue in Eclipse Jetty's `HttpURI` parser, affecting
+Jetty from 7.0.0 up to (but not including) 12.0.12 (fixed in 12.0.12, with a 9.4.57 backport on the
+still-supported 9.4.x branch). Solr bundles Jetty as its HTTP server, so scanners flag this CVE on
+every Solr release whose Jetty predates 12.0.12 — Jetty 8.1.x/9.4.x/10.0.x from Solr 4.0.0 through
+Solr 9.10.1. Solr 10.0.0 ships Jetty 12.0.27 (≥ 12.0.12) and is not affected. The affected range is
+therefore 4.0.0 – 9.10.1.
+
+Solr is **not affected**: it does not use the Jetty "HttpURI" utility class necessary for the vulnerability.

--- a/content/solr/vex/2025-08-02-cve-2024-7254.md
+++ b/content/solr/vex/2025-08-02-cve-2024-7254.md
@@ -3,9 +3,18 @@ cve: CVE-2024-7254
 jira: SOLR-17833
 category:
   - solr/vex
-versions: "≤ 9.9.0"
+versions: "4.4.0-9.9.0"
+jars:
+  - protobuf-java-3.25.3.jar
 analysis:
   state: in_triage
 title: "protobuf-java: Potential Denial of Service issue"
 ---
 When parsing unknown fields in the Protobuf Java Lite and Full library, a maliciously crafted message can cause a StackOverflow error and lead to a program crash.
+
+CVE-2024-7254 affects all `protobuf-java` releases before 3.25.5 (per the upstream advisory the
+flaw was introduced at version 0, and is fixed in 3.25.5 / 4.27.5 / 4.28.2). Apache Solr has bundled
+`protobuf-java` (transitively, via Hadoop and ZooKeeper) since **Solr 4.4.0** (which shipped 2.4.0a),
+and every release from 4.4.0 through 9.9.0 ships an affected version (2.4.0a through 3.25.3). Solr
+**9.10.0** was the first release to ship a fixed `protobuf-java` (3.25.8), so the affected range is
+**4.4.0 – 9.9.0**.

--- a/content/solr/vex/2025-08-04-cve-2025-48924.md
+++ b/content/solr/vex/2025-08-04-cve-2025-48924.md
@@ -3,9 +3,21 @@ cve: CVE-2025-48924
 category:
   - solr/vex
 versions: "9.0.0-9.9.0"
+jars:
+  - commons-lang3-3.15.0.jar
 analysis:
   state: not_affected
   justification: "code_not_reachable"
-title: "commons-lang3-<version>.jar"
+title: "Apache Commons Lang: uncontrolled recursion in ClassUtils.getClass"
 ---
-The vulnerable functionality is only reachable via `commons-configuration2`, which is used in Solr's Hadoop Kerberos support (`solr-hadoop-auth`) to load administrator-provided Hadoop configuration files. As such, the vulnerability is not exploitable in Solr.
+CVE-2025-48924 is an uncontrolled-recursion issue in Apache Commons Lang's
+`ClassUtils.getClass(...)`: a very long, deeply-nested class name can exhaust the stack and
+throw `StackOverflowError`. It affects `commons-lang3` from 3.0 up to (but not including) 3.18.0,
+so dependency scanners flag the `commons-lang3` JAR bundled in Solr 9.x (which ships versions
+3.12.0 through 3.15.0 across the 9.0–9.9 line).
+
+Solr is **not affected**. The vulnerable `ClassUtils.getClass(...)` code path is only reachable via
+`commons-configuration2`, which Solr uses solely in its Hadoop Kerberos support
+(`solr-hadoop-auth`) to load administrator-provided Hadoop configuration files. Class names are not
+attacker-controlled in that path, so the recursion cannot be driven by an adversary and the
+vulnerability is not exploitable in Solr.

--- a/content/solr/vex/2026-05-04-cve-2026-40682.md
+++ b/content/solr/vex/2026-05-04-cve-2026-40682.md
@@ -2,7 +2,7 @@
 cve: CVE-2026-40682
 category:
   - solr/vex
-versions: "< 10.1.0"
+versions: "7.3.0-10.0.0"
 jars:
   - opennlp-tools-1.9.4.jar
 analysis:
@@ -52,5 +52,10 @@ archive passes through a single chokepoint before OpenNLP is allowed to deserial
 to both standalone (filesystem configset) and SolrCloud (ZooKeeper) deployments, and whether the
 dictionary is loaded by the `langid` / `analysis-extras` update processors or by the
 schema-configured OpenNLP analyzers.
+
+This flaw is present in every OpenNLP release before 2.5.9 (fixed in 2.5.9 / 3.0.0-M3, backported to
+1.9.5). Solr has bundled OpenNLP (transitively, via `lucene-analysis-opennlp`) since Solr 7.3.0, so
+every release from 7.3.0 through 10.0.0 ships an affected version (1.8.3 through 2.5.6). The affected
+range is therefore 7.3.0 – 10.0.0.
 
 Fully resolved in Solr 10.1 by upgrading the bundled OpenNLP (via `lucene-analysis-opennlp`) to 2.5.9.

--- a/content/solr/vex/2026-05-04-cve-2026-42027.md
+++ b/content/solr/vex/2026-05-04-cve-2026-42027.md
@@ -2,7 +2,7 @@
 cve: CVE-2026-42027
 category:
   - solr/vex
-versions: "< 10.1.0"
+versions: "7.3.0-10.0.0"
 jars:
   - opennlp-tools-1.9.4.jar
 analysis:
@@ -61,5 +61,10 @@ deserialize it:
 
 Solr's own usage only ever references built-in `opennlp.*` factories, so legitimate models load
 unchanged; only crafted models that try to instantiate arbitrary classes are blocked.
+
+This flaw is present in every OpenNLP release before 2.5.9 (fixed in 2.5.9 / 3.0.0-M3, backported to
+1.9.5). Solr has bundled OpenNLP (transitively, via `lucene-analysis-opennlp`) since Solr 7.3.0, so
+every release from 7.3.0 through 10.0.0 ships an affected version (1.8.3 through 2.5.6). The affected
+range is therefore 7.3.0 – 10.0.0.
 
 Fully resolved in Solr 10.1 by upgrading the bundled OpenNLP (via `lucene-analysis-opennlp`) to 2.5.9.

--- a/content/solr/vex/2026-05-04-cve-2026-42440.md
+++ b/content/solr/vex/2026-05-04-cve-2026-42440.md
@@ -2,7 +2,7 @@
 cve: CVE-2026-42440
 category:
   - solr/vex
-versions: "< 10.1.0"
+versions: "7.3.0-10.0.0"
 jars:
   - opennlp-tools-1.9.4.jar
 analysis:
@@ -21,9 +21,10 @@ model file with a count set to `Integer.MAX_VALUE` triggers an immediate `OutOfM
 model deserialization, before any substantial data is consumed.
 
 The vulnerable code is present in the `opennlp-tools-1.9.4.jar` that Solr pulls in transitively via
-`lucene-analysis-opennlp` (Lucene 9.12.3). There is a `opennlp-tools-1.9.5` release happening, but it hasn't finished or been integrated into Solr 9; the issue is fixed in OpenNLP 2.5.9 (and 3.0.0-M3), which validate the count against an
-upper bound (default 10,000,000, configurable via the `OPENNLP_MAX_ENTRIES` system property) before
-allocating.
+`lucene-analysis-opennlp` (Lucene 9.12.3). The issue is fixed upstream in OpenNLP 2.5.9 (and
+3.0.0-M3), and backported to the end-of-life 1.9.x line as `opennlp-tools-1.9.5`; all of these
+validate the count against an upper bound (default 10,000,000, configurable via the
+`OPENNLP_MAX_ENTRIES` system property) before allocating.
 
 #### When Solr is exposed
 
@@ -45,4 +46,10 @@ The most reliable mitigation is to **not enable the OpenNLP-backed `analysis-ext
 modules** unless they are required. If you do use OpenNLP, load model files only from locations you
 fully control and never from untrusted or user-supplied sources.
 
-Fully resolved in Solr 10.1 by upgrading the bundled OpenNLP (via `lucene-analysis-opennlp`) to 2.5.9.
+This flaw is present in every OpenNLP release before 2.5.9. Solr has bundled OpenNLP (transitively,
+via `lucene-analysis-opennlp`) since Solr 7.3.0, so every release from 7.3.0 through 10.0.0 ships an
+affected version (1.8.3 through 2.5.6). The affected range is therefore 7.3.0 – 10.0.0.
+
+Fixed in Solr 9.11, which bundles the patched `opennlp-tools` 1.9.5, and in Solr 10.1, which upgrades
+the bundled OpenNLP (via `lucene-analysis-opennlp`) to 2.5.9. Solr 10.0 remains affected (it ships
+OpenNLP 2.5.6).

--- a/content/solr/vex/2026-06-18-cve-2025-11143.md
+++ b/content/solr/vex/2026-06-18-cve-2025-11143.md
@@ -2,7 +2,7 @@
 cve: CVE-2025-11143
 category:
   - solr/vex
-versions: "≤ 9.x"
+versions: "7.3.0-10.0.0"
 jars:
   - jetty-http-10.0.26.jar
 analysis:
@@ -44,4 +44,7 @@ production-secure deployment and explicitly warns against relying on network-per
 sole access mechanism. A deployment without Solr auth that relies on a proxy's URI rules as its only
 security boundary is therefore outside the project's supported production configuration.
 
-Solr 10.0 ships the fixed Jetty 12.0.34.
+Solr has bundled a Jetty version in an affected branch (≥ 9.4.0) since Solr 7.3.0 — Jetty 9.4.x
+through Solr 9.1, Jetty 10.0.x through Solr 9.10, and Jetty 12.0.27 in Solr 10.0.0 (below the fixed
+12.0.31) — so scanners flag this CVE across Solr 7.3.0 – 10.0.0. As explained above, Solr is not
+affected in a supported (authenticated) configuration throughout that range.

--- a/content/solr/vex/2026-06-18-cve-2026-2332.md
+++ b/content/solr/vex/2026-06-18-cve-2026-2332.md
@@ -2,7 +2,7 @@
 cve: CVE-2026-2332
 category:
   - solr/vex
-versions: "≤ 9.x"
+versions: "7.3.0-10.0.0"
 jars:
   - jetty-http-10.0.26.jar
 analysis:
@@ -57,4 +57,8 @@ and reaches Solr's APIs directly, bypassing those controls.
 * **Upgrade the bundled Jetty** to a patched release (≥ 10.0.28 on the 10.0.x line), which is the
   full fix, however that requires commercial support. See https://webtide.com/end-of-life/ for options.
 
-Solr 10.0 ships the fixed Jetty 12.0.34.
+Solr has bundled a Jetty version in an affected branch (≥ 9.4.0) since Solr 7.3.0 — Jetty 9.4.x
+through Solr 9.1, Jetty 10.0.x through Solr 9.10, and Jetty 12.0.27 in Solr 10.0.0 (which is still
+below the fixed 12.0.33). Earlier releases shipped Jetty 9.2.x/9.3.x or 8.1.x, which pre-date the
+affected 9.4.0 branch. The affected range is therefore 7.3.0 – 10.0.0; no released Solr yet bundles a
+fixed Jetty (≥ 10.0.28 / 12.0.33).

--- a/content/solr/vex/2026-06-18-cve-2026-5795.md
+++ b/content/solr/vex/2026-06-18-cve-2026-5795.md
@@ -2,7 +2,7 @@
 cve: CVE-2026-5795
 category:
   - solr/vex
-versions: "≤ 9.x"
+versions: "7.3.0-10.0.0"
 jars:
   - jetty-server-10.0.26.jar
 analysis:
@@ -29,4 +29,8 @@ Jetty 9.4.44 in earlier 9.x releases), so dependency scanners flag this CVE. Sol
   PKI, etc.). It never installs a Jetty `SecurityHandler`/`Authenticator`, and never the JASPI
   mechanism, so the vulnerable code path is unreachable even if the module were present.
 
-Solr 10.0 ships the fixed Jetty 12.0.34.
+Solr has bundled a Jetty version in an affected branch (≥ 9.4.0) since Solr 7.3.0 — Jetty 9.4.x
+through Solr 9.1, Jetty 10.0.x through Solr 9.10, and Jetty 12.0.27 in Solr 10.0.0 (below the fixed
+12.0.34) — so scanners flag this CVE across Solr 7.3.0 – 10.0.0. Solr remains **not affected**
+throughout that range because it never ships the `jetty-jaspi` module, regardless of the bundled
+Jetty version.


### PR DESCRIPTION
The VEX files we have didn't always have the specific jar files that were impacted.   They also had fairly loose ranges, with no beginning defined.   

This PR goes through the vex files, and with Claude's help, tries to figure out when a vulnerability was introduced by looking at the Solr lockfiles etc to figure it out.   