### PR TITLE
Add missing jars field to two dependency VEX entries

### DIFF
--- a/content/solr/vex/2025-08-02-cve-2024-7254.md
+++ b/content/solr/vex/2025-08-02-cve-2024-7254.md
@@ -4,6 +4,8 @@ jira: SOLR-17833
 category:
   - solr/vex
 versions: "≤ 9.9.0"
+jars:
+  - protobuf-java-3.25.3.jar
 analysis:
   state: in_triage
 title: "protobuf-java: Potential Denial of Service issue"

--- a/content/solr/vex/2025-08-04-cve-2025-48924.md
+++ b/content/solr/vex/2025-08-04-cve-2025-48924.md
@@ -3,9 +3,11 @@ cve: CVE-2025-48924
 category:
   - solr/vex
 versions: "9.0.0-9.9.0"
+jars:
+  - commons-lang3-3.15.0.jar
 analysis:
   state: not_affected
   justification: "code_not_reachable"
-title: "commons-lang3-<version>.jar"
+title: "commons-lang3"
 ---
 The vulnerable functionality is only reachable via `commons-configuration2`, which is used in Solr's Hadoop Kerberos support (`solr-hadoop-auth`) to load administrator-provided Hadoop configuration files. As such, the vulnerability is not exploitable in Solr.


### PR DESCRIPTION
## Summary
- CVE-2024-7254 (protobuf-java) and CVE-2025-48924 (commons-lang3) were missing their `jars` front matter, so both were treated as advisory-only Solr-native entries and excluded from the dependency-CVE table even though they're genuine third-party dependency vulnerabilities.
- Also fixes the commons-lang3 entry's leftover placeholder title (`"commons-lang3-<version>.jar"` → `"commons-lang3"`).

## Test plan
- [x] `pelican` build succeeds with no new errors
- [x] Confirmed both entries now appear in the dependency-CVE table data (`a['jars']` non-empty) via `read_vex_articles`

🤖 Generated with [Claude Code](https://claude.com/claude-code)