### PR TITLE
Reviewing remaining cves for 9.11-SNAPSHOT and 10.1-SNAPSHOT Docker images

### DIFF
--- a/content/solr/vex/2025-08-02-cve-2024-7254.md
+++ b/content/solr/vex/2025-08-02-cve-2024-7254.md
@@ -7,10 +7,26 @@ versions: "4.4.0-9.9.0"
 jars:
   - protobuf-java-3.25.3.jar
 analysis:
-  state: in_triage
+  state: not_affected
+  justification: code_not_reachable
 title: "protobuf-java: Potential Denial of Service issue"
 ---
 When parsing unknown fields in the Protobuf Java Lite and Full library, a maliciously crafted message can cause a StackOverflow error and lead to a program crash.
+
+Solr is **not affected**. The crafted-message DoS requires an attacker to feed protobuf input to a
+parser, and Solr exposes no such path:
+
+* **Solr's own code never uses protobuf.** There is no `com.google.protobuf` usage anywhere in the
+  Solr codebase, and Solr's client-facing APIs speak javabin, JSON and XML — never protobuf. The SQL
+  module is reached through `SQLHandler` (Calcite runs in-process, returning tuples); Solr exposes no
+  Avatica/protobuf wire endpoint to clients.
+* **protobuf-java is only used to talk to trusted infrastructure.** It is pulled in transitively for
+  communication with operator-controlled endpoints — the ZooKeeper ensemble, Hadoop RPC (HDFS /
+  Kerberos), the Google Cloud Storage backup API, the OpenTelemetry OTLP collector, and the Kafka
+  cross-DC pipeline. An external attacker cannot supply the deeply-nested message the DoS requires to
+  any of those parsers.
+
+Tracked upstream as SOLR-17833.
 
 CVE-2024-7254 affects all `protobuf-java` releases before 3.25.5 (per the upstream advisory the
 flaw was introduced at version 0, and is fixed in 3.25.5 / 4.27.5 / 4.28.2). Apache Solr has bundled

--- a/content/solr/vex/2026-05-04-cve-2026-40682.md
+++ b/content/solr/vex/2026-05-04-cve-2026-40682.md
@@ -2,7 +2,7 @@
 cve: CVE-2026-40682
 category:
   - solr/vex
-versions: "7.3.0-10.0.0"
+versions: "7.3.0-9.10.1,10.0.0"
 jars:
   - opennlp-tools-1.9.4.jar
 analysis:
@@ -22,9 +22,10 @@ OpenNLP deserializes — can therefore read local files from the server or trigg
 (server-side request forgery). Other OpenNLP XML parsing paths route through the hardened
 `XmlUtil.createSaxParser()` helper, but this code path does not.
 
-The vulnerable code is present in the `opennlp-tools-1.9.4.jar` that Solr pulls in transitively via
-`lucene-analysis-opennlp` (Lucene 9.12.3). There is a `opennlp-tools-1.9.5` release happening, but it hasn't finished or been integrated into Solr 9; the issue is fixed in OpenNLP 2.5.9 (and 3.0.0-M3), which parse dictionaries with secure
-XML processing that rejects DOCTYPE declarations and external entities.
+The vulnerable code is present in the `opennlp-tools-1.9.4.jar` that Solr's 9.x line pulls in
+transitively via `lucene-analysis-opennlp` (Lucene 9.12.3). The issue is fixed in OpenNLP 2.5.9 (and
+3.0.0-M3), and backported to the 1.9.x line as `opennlp-tools-1.9.5`; all of these parse dictionaries
+with secure XML processing that rejects DOCTYPE declarations and external entities.
 
 #### When Solr is exposed
 
@@ -53,9 +54,12 @@ to both standalone (filesystem configset) and SolrCloud (ZooKeeper) deployments,
 dictionary is loaded by the `langid` / `analysis-extras` update processors or by the
 schema-configured OpenNLP analyzers.
 
-This flaw is present in every OpenNLP release before 2.5.9 (fixed in 2.5.9 / 3.0.0-M3, backported to
-1.9.5). Solr has bundled OpenNLP (transitively, via `lucene-analysis-opennlp`) since Solr 7.3.0, so
-every release from 7.3.0 through 10.0.0 ships an affected version (1.8.3 through 2.5.6). The affected
-range is therefore 7.3.0 – 10.0.0.
+Solr has bundled OpenNLP (via `lucene-analysis-opennlp`) since Solr 7.3.0. Every release from 7.3.0
+through the 9.10.x line ships an affected `opennlp-tools` (1.8.3 through 1.9.4), and Solr 10.0.0 ships
+the affected 2.5.6. Solr **9.11** upgrades to the patched `opennlp-tools` 1.9.5 (the 1.9.x backport)
+and Solr **10.1** upgrades to 2.5.9, so both are fixed. The affected (exploitable) range is therefore
+**7.3.0 – 9.10.1 and 10.0.0**.
 
-Fully resolved in Solr 10.1 by upgrading the bundled OpenNLP (via `lucene-analysis-opennlp`) to 2.5.9.
+Note: advisory databases record the fix only as OpenNLP 2.5.9, so a dependency scanner may still flag
+the backported `opennlp-tools` 1.9.5 that Solr 9.11 ships — a false positive, since 1.9.5 contains the
+backported fix.

--- a/content/solr/vex/2026-05-04-cve-2026-42027.md
+++ b/content/solr/vex/2026-05-04-cve-2026-42027.md
@@ -2,7 +2,7 @@
 cve: CVE-2026-42027
 category:
   - solr/vex
-versions: "7.3.0-10.0.0"
+versions: "7.3.0-9.10.1,10.0.0"
 jars:
   - opennlp-tools-1.9.4.jar
 analysis:
@@ -22,8 +22,9 @@ model archive can trigger the static initializer of any class on the classpath (
 performs a JNDI lookup, outbound network I/O, or filesystem access), regardless of the
 type check that follows.
 
-The vulnerable code is present in the `opennlp-tools-1.9.4.jar` that Solr pulls in transitively
-via `lucene-analysis-opennlp` (Lucene 9.12.3). There is a `opennlp-tools-1.9.5` release happening, but it hasn't finished or been integrated into Solr 9; the issue is fixed in OpenNLP 2.5.9 (and 3.0.0-M3), which consults a
+The vulnerable code is present in the `opennlp-tools-1.9.4.jar` that Solr's 9.x line pulls in
+transitively via `lucene-analysis-opennlp` (Lucene 9.12.3). The issue is fixed upstream in OpenNLP
+2.5.9 (and 3.0.0-M3), and backported to the 1.9.x line as `opennlp-tools-1.9.5`; the fix consults a
 package-prefix allowlist *before* calling `Class.forName()`.
 
 #### When Solr is exposed
@@ -44,9 +45,8 @@ The most reliable mitigation is to **not enable the OpenNLP-backed `analysis-ext
 modules** unless they are required. If you do use OpenNLP, load model files only from locations you
 fully control and never from untrusted or user-supplied sources.
 
-In Solr 9.11.0 the upstream allowlist defense is backfilled at the application layer, since the
-vulnerable jar cannot yet be upgraded (Solr must track the OpenNLP version used by
-`lucene-analysis-opennlp`). Every OpenNLP model is loaded as a resource through Solr's resource
+As defense in depth, Solr 9.11 also validates OpenNLP models at the application layer before they
+reach `ExtensionLoader`. Every OpenNLP model is loaded as a resource through Solr's resource
 loaders, so the archive is validated at that single chokepoint before OpenNLP is allowed to
 deserialize it:
 
@@ -62,9 +62,12 @@ deserialize it:
 Solr's own usage only ever references built-in `opennlp.*` factories, so legitimate models load
 unchanged; only crafted models that try to instantiate arbitrary classes are blocked.
 
-This flaw is present in every OpenNLP release before 2.5.9 (fixed in 2.5.9 / 3.0.0-M3, backported to
-1.9.5). Solr has bundled OpenNLP (transitively, via `lucene-analysis-opennlp`) since Solr 7.3.0, so
-every release from 7.3.0 through 10.0.0 ships an affected version (1.8.3 through 2.5.6). The affected
-range is therefore 7.3.0 – 10.0.0.
+Solr has bundled OpenNLP (via `lucene-analysis-opennlp`) since Solr 7.3.0. Every release from 7.3.0
+through the 9.10.x line ships an affected `opennlp-tools` (1.8.3 through 1.9.4), and Solr 10.0.0 ships
+the affected 2.5.6. Solr **9.11** is fixed — it upgrades to the patched `opennlp-tools` 1.9.5 (the
+1.9.x backport) and adds the application-layer allowlist described above — and Solr **10.1** upgrades
+to 2.5.9. The affected (exploitable) range is therefore **7.3.0 – 9.10.1 and 10.0.0**.
 
-Fully resolved in Solr 10.1 by upgrading the bundled OpenNLP (via `lucene-analysis-opennlp`) to 2.5.9.
+Note: advisory databases record the fix only as OpenNLP 2.5.9, so a dependency scanner may still flag
+the backported `opennlp-tools` 1.9.5 that Solr 9.11 ships — a false positive, since 1.9.5 (plus Solr's
+own allowlist) closes this issue.

--- a/content/solr/vex/2026-05-04-cve-2026-42440.md
+++ b/content/solr/vex/2026-05-04-cve-2026-42440.md
@@ -2,7 +2,7 @@
 cve: CVE-2026-42440
 category:
   - solr/vex
-versions: "7.3.0-10.0.0"
+versions: "7.3.0-9.10.1,10.0.0"
 jars:
   - opennlp-tools-1.9.4.jar
 analysis:
@@ -22,9 +22,9 @@ model deserialization, before any substantial data is consumed.
 
 The vulnerable code is present in the `opennlp-tools-1.9.4.jar` that Solr pulls in transitively via
 `lucene-analysis-opennlp` (Lucene 9.12.3). The issue is fixed upstream in OpenNLP 2.5.9 (and
-3.0.0-M3), and backported to the end-of-life 1.9.x line as `opennlp-tools-1.9.5`; all of these
-validate the count against an upper bound (default 10,000,000, configurable via the
-`OPENNLP_MAX_ENTRIES` system property) before allocating.
+3.0.0-M3), which validate the count against an upper bound (default 10,000,000, configurable via the
+`OPENNLP_MAX_ENTRIES` system property) before allocating, and backported to the 1.9.x line as
+`opennlp-tools-1.9.5`.
 
 #### When Solr is exposed
 
@@ -46,10 +46,12 @@ The most reliable mitigation is to **not enable the OpenNLP-backed `analysis-ext
 modules** unless they are required. If you do use OpenNLP, load model files only from locations you
 fully control and never from untrusted or user-supplied sources.
 
-This flaw is present in every OpenNLP release before 2.5.9. Solr has bundled OpenNLP (transitively,
-via `lucene-analysis-opennlp`) since Solr 7.3.0, so every release from 7.3.0 through 10.0.0 ships an
-affected version (1.8.3 through 2.5.6). The affected range is therefore 7.3.0 – 10.0.0.
+Solr has bundled OpenNLP (via `lucene-analysis-opennlp`) since Solr 7.3.0. Every release from 7.3.0
+through the 9.10.x line ships an affected `opennlp-tools` (1.8.3 through 1.9.4), and Solr 10.0.0 ships
+the affected 2.5.6. Solr **9.11** upgrades to the patched `opennlp-tools` 1.9.5 (the 1.9.x backport)
+and Solr **10.1** upgrades to 2.5.9, so both are fixed. The affected (exploitable) range is therefore
+**7.3.0 – 9.10.1 and 10.0.0**.
 
-Fixed in Solr 9.11, which bundles the patched `opennlp-tools` 1.9.5, and in Solr 10.1, which upgrades
-the bundled OpenNLP (via `lucene-analysis-opennlp`) to 2.5.9. Solr 10.0 remains affected (it ships
-OpenNLP 2.5.6).
+Note: advisory databases record the fix only as OpenNLP 2.5.9, so a dependency scanner may still flag
+the backported `opennlp-tools` 1.9.5 that Solr 9.11 ships — a false positive, since 1.9.5 contains the
+backported fix.

--- a/content/solr/vex/2026-07-31-cve-2024-47561.md
+++ b/content/solr/vex/2026-07-31-cve-2024-47561.md
@@ -1,0 +1,32 @@
+---
+cve:
+  - CVE-2024-47561
+  - CVE-2023-39410
+category:
+  - solr/vex
+versions: "9.0.0-9.10.1"
+jars:
+  - avro-1.9.2.jar
+analysis:
+  state: not_affected
+  justification: code_not_reachable
+title: "Apache Avro (Java): RCE reading a crafted schema / DoS deserializing untrusted data"
+---
+CVE-2024-47561 (critical) is an arbitrary-code-execution issue in the Apache Avro Java SDK: parsing
+an attacker-controlled Avro **schema** can instantiate arbitrary classes (affects avro < 1.11.4).
+CVE-2023-39410 is a memory-exhaustion / DoS issue when **deserializing untrusted Avro data** (affects
+avro < 1.11.3). Both require the application to feed attacker-controlled Avro input to the SDK.
+
+Solr is **not affected**:
+
+* **Solr does not use Apache Avro.** There is no `org.apache.avro` usage anywhere in the Solr
+  codebase, and Solr ships no standalone `avro-*.jar`. Avro appears only as an embedded/transitive
+  artifact of the optional Hadoop integration (the `hdfs` / `hadoop-auth` modules, which are not part
+  of a default install).
+* **The vulnerable entry points are never reached.** Solr never parses an externally-supplied Avro
+  schema and never deserializes untrusted Avro data — the only code that pulls Avro in is Hadoop's
+  own internal machinery, driven by administrator-supplied configuration, not by untrusted request
+  input.
+
+The affected range covers the 9.x line, where the optional Hadoop modules transitively carry Avro
+1.9.2; Solr's own code path never invokes it.

--- a/content/solr/vex/2026-07-31-cve-2025-49128.md
+++ b/content/solr/vex/2026-07-31-cve-2025-49128.md
@@ -1,0 +1,19 @@
+---
+cve: CVE-2025-49128
+category:
+  - solr/vex
+versions: "4.7.0-10.0.0"
+jars:
+  - jackson-core-2.12.7.jar
+analysis:
+  state: not_affected
+  justification: code_not_reachable
+title: "jackson-core: memory disclosure via source snippet in JsonLocation error messages"
+---
+CVE-2025-49128 can disclose adjacent buffer memory through the source snippet that jackson-core
+includes in `JsonLocation` (e.g. surfaced in parse-error messages). It affects jackson-core < 2.13.0.
+
+Solr is **not affected**. Solr's own jackson-core is 2.18.0 in current 9.x and 2.22.0 in 9.11 — both
+well past the 2.13.0 fix. The `2.12.7` copy a scanner flags is Hadoop's shaded jackson-core,
+reachable only via the optional Hadoop modules, which parse administrator-supplied configuration
+rather than untrusted external JSON, and whose parse errors are not returned to remote clients.

--- a/content/solr/vex/2026-07-31-cve-2025-52999.md
+++ b/content/solr/vex/2026-07-31-cve-2025-52999.md
@@ -1,0 +1,27 @@
+---
+cve:
+  - GHSA-r7wm-3cxj-wff9
+  - CVE-2025-52999
+category:
+  - solr/vex
+versions: "4.7.0-10.0.0"
+jars:
+  - jackson-core-2.12.7.jar
+analysis:
+  state: not_affected
+  justification: code_not_reachable
+title: "jackson-core: async-parser number-length bypass and deep-nesting StackOverflow (DoS)"
+---
+GHSA-r7wm-3cxj-wff9 is a `maxNumberLength` bypass in jackson-core's **async / non-blocking** parser
+(an incomplete fix for GHSA-72hv-8253-57qq; affects < 2.18.8 and 2.19.0–2.21.3). CVE-2025-52999 is a
+`StackOverflowError` when parsing **very deeply nested** input (affects < 2.15.0).
+
+Solr is **not affected**:
+
+* **The async parser is never used.** Solr deserializes JSON with the standard *synchronous* Jackson
+  parser; it never calls the non-blocking `NonBlockingByteArrayParser` API, so the async-only
+  `maxNumberLength` bypass (GHSA-r7wm) is unreachable — as already assessed for GHSA-72hv-8253-57qq.
+* **Solr's own jackson-core is patched.** The bundled jackson-core is 2.18.0 in current 9.x and
+  2.22.0 in 9.11 — both fixed for the deep-nesting StackOverflow (fixed in 2.15.0). The `2.12.7`
+  copy a scanner flags is Hadoop's **shaded** jackson, reachable only through the optional Hadoop
+  modules, which parse administrator-supplied configuration rather than untrusted external JSON.

--- a/content/solr/vex/2026-07-31-cve-2025-53864.md
+++ b/content/solr/vex/2026-07-31-cve-2025-53864.md
@@ -1,0 +1,20 @@
+---
+cve: CVE-2025-53864
+category:
+  - solr/vex
+versions: "9.0.0-10.0.0"
+jars:
+  - nimbus-jose-jwt-9.37.2.jar
+analysis:
+  state: not_affected
+  justification: code_not_reachable
+title: "Nimbus JOSE + JWT: uncontrolled recursion (DoS) parsing crafted JOSE objects"
+---
+CVE-2025-53864 is an uncontrolled-recursion denial-of-service in the Nimbus JOSE + JWT library when
+parsing a maliciously crafted, deeply-nested JOSE object (affects 9.37.x < 9.37.4 and 10.0.x < 10.0.2).
+
+Solr is **not affected**. Solr's JWT authentication (the optional `jwt-auth` module, `JWTAuthPlugin`)
+parses and validates tokens exclusively with **jose4j** (`org.jose4j.*` — the plugin imports jose4j
+and does not reference `com.nimbusds` at all). Nimbus JOSE + JWT is not on Solr's JWT-processing code
+path; it appears only as a transitive/declared reference and is never invoked to parse an incoming
+token, so the vulnerable recursive parser cannot be reached by an attacker-supplied JWT.

--- a/content/solr/vex/2026-07-31-cve-2026-10050.md
+++ b/content/solr/vex/2026-07-31-cve-2026-10050.md
@@ -1,0 +1,23 @@
+---
+cve: CVE-2026-10050
+category:
+  - solr/vex
+versions: "7.3.0-10.0.0"
+jars:
+  - jetty-security-10.0.26.jar
+analysis:
+  state: not_affected
+  justification: code_not_reachable
+title: "Eclipse Jetty: Digest authentication lossy encoding"
+---
+CVE-2026-10050 is a lossy-encoding flaw in Eclipse Jetty's **Digest authentication** implementation
+(in `jetty-security`), which can weaken Digest credential handling. It affects the Jetty branches
+Solr ships (10.0.x through 10.0.30, and 12.0.x through 12.0.35; fixed in 10.0.31 / 12.0.36 / 12.1.10).
+
+Solr is **not affected**. Solr bundles `jetty-security` as part of the Jetty server stack, but it
+does not use Jetty's declarative security: it never installs a Jetty `SecurityHandler` /
+`ConstraintSecurityHandler` and never configures a Jetty `Authenticator` (Digest or otherwise). Solr
+authenticates requests in its own servlet filter (`SolrDispatchFilter` / the `AuthenticationPlugin`
+framework — Basic, JWT, Kerberos, PKI, etc.), so Jetty's Digest-authentication code path — the code
+this CVE affects — is never invoked. The affected range spans the releases whose bundled Jetty is in
+an affected branch (Solr 7.3.0 – 10.0.0).

--- a/content/solr/vex/2026-07-31-cve-2026-10051.md
+++ b/content/solr/vex/2026-07-31-cve-2026-10051.md
@@ -1,0 +1,22 @@
+---
+cve: CVE-2026-10051
+category:
+  - solr/vex
+versions: "7.3.0-10.0.0"
+jars:
+  - jetty-server-10.0.26.jar
+analysis:
+  state: not_affected
+  justification: code_not_reachable
+title: "Eclipse Jetty: HTTP/1.1 request trailers leak across keep-alive requests"
+---
+CVE-2026-10051 is an information-exposure bug in Jetty's `HttpConnection`: the `_trailers` field is
+not reset between requests on an HTTP/1.1 keep-alive connection, so trailer fields from one request
+can be observed via `getTrailers()` on a later request on the same connection. It has security impact
+only for applications that **read HTTP trailers** (`request.getTrailers()`) and use them for logic or
+security decisions.
+
+Solr is **not affected**. Solr does not read HTTP request trailers anywhere — there is no
+`getTrailers()` / trailer-field usage in the Solr codebase — so stale trailer state on a pooled
+connection is never observed by Solr and cannot influence request handling or authorization. The
+affected range spans the releases whose bundled Jetty is in an affected branch (Solr 7.3.0 – 10.0.0).

--- a/content/solr/vex/2026-07-31-cve-2026-43869.md
+++ b/content/solr/vex/2026-07-31-cve-2026-43869.md
@@ -1,0 +1,24 @@
+---
+cve: CVE-2026-43869
+category:
+  - solr/vex
+versions: "9.0.0-10.0.0"
+jars:
+  - libthrift-0.15.0.jar
+analysis:
+  state: not_affected
+  justification: requires_configuration
+title: "Apache Thrift (Java): TLS hostname verification in TSSLTransportFactory"
+---
+CVE-2026-43869 is a TLS hostname-verification weakness in Apache Thrift's
+`TSSLTransportFactory` (affects libthrift ≤ 0.22.0, fixed in 0.23.0): a client using Thrift's TLS
+transport may not properly verify the server certificate's hostname, enabling a man-in-the-middle on
+that connection.
+
+Solr is **not affected** in any default or recommended configuration. `libthrift` is bundled only by
+the optional, opt-in **`jaegertracer-configurator`** module (Jaeger distributed-tracing exporter) —
+it is not part of a default Solr install, and Solr does not use Thrift's TLS transport anywhere else.
+Even when Jaeger tracing is enabled, Solr exports spans to an **operator-configured** Jaeger backend
+(a trusted, first-party collector), not to an untrusted remote host, so there is no untrusted TLS
+peer for the missing hostname check to expose. The issue is only relevant to an operator who both
+enables Jaeger tracing and deliberately points it at an untrusted TLS endpoint.

--- a/content/solr/vex/2026-07-31-cve-2026-45205.md
+++ b/content/solr/vex/2026-07-31-cve-2026-45205.md
@@ -1,0 +1,20 @@
+---
+cve: CVE-2026-45205
+category:
+  - solr/vex
+versions: "9.0.0-10.0.0"
+jars:
+  - commons-configuration2-2.10.1.jar
+analysis:
+  state: not_affected
+  justification: code_not_reachable
+title: "Apache Commons Configuration: StackOverflowError for YAML input with cycles"
+---
+CVE-2026-45205 is a `StackOverflowError` (DoS) when Apache Commons Configuration parses YAML input
+containing reference cycles (affects 2.2 – 2.14.x, fixed in 2.15.0).
+
+Solr is **not affected**. Solr uses `commons-configuration2` only transitively, via the optional
+Hadoop integration (Kerberos / HDFS support), to load **administrator-supplied** Hadoop configuration
+files — not untrusted, externally-supplied YAML. No Solr request path feeds attacker-controlled YAML
+to Commons Configuration, so the cyclic-YAML parser cannot be driven by an adversary. (This matches
+the existing assessment of the other Commons Configuration CVEs in Solr.)

--- a/content/solr/vex/2026-07-31-cve-2026-46718.md
+++ b/content/solr/vex/2026-07-31-cve-2026-46718.md
@@ -1,0 +1,22 @@
+---
+cve: CVE-2026-46718
+category:
+  - solr/vex
+versions: "9.0.0-10.0.0"
+jars:
+  - calcite-core-1.37.0.jar
+analysis:
+  state: not_affected
+  justification: code_not_reachable
+title: "Apache Calcite: arbitrary class loading via a user-controlled model"
+---
+CVE-2026-46718 lets a **user-controlled Calcite model** load arbitrary classes, leading to code
+execution (affects calcite-core 1.5.0 – 1.41.x, fixed in 1.42.0). Exploitation requires the
+application to let an attacker supply the Calcite *model* (the JSON schema/model definition that can
+name factory classes).
+
+Solr is **not affected**. Calcite is used only by the optional `sql` module (Parallel SQL, the `/sql`
+handler). Solr constructs the Calcite schema/model **server-side** from the target collection; users
+submit only a SQL statement, never a Calcite model or schema-factory definition. There is no request
+path through which an attacker can supply a Calcite model, so the arbitrary-class-loading vector is
+never reached.

--- a/content/solr/vex/2026-07-31-cve-2026-50193.md
+++ b/content/solr/vex/2026-07-31-cve-2026-50193.md
@@ -1,0 +1,36 @@
+---
+cve:
+  - CVE-2026-50193
+  - CVE-2026-54514
+  - CVE-2026-54515
+  - CVE-2026-59889
+  - CVE-2026-59888
+  - GHSA-mhm7-754m-9p8w
+category:
+  - solr/vex
+versions: "4.7.0-10.0.0"
+jars:
+  - jackson-databind-2.12.7.1.jar
+analysis:
+  state: not_affected
+  justification: code_not_reachable
+title: "jackson-databind: nested-toString DoS, InetSocketAddress SSRF, and deserialization-filter bypasses"
+---
+Four jackson-databind issues, in two groups:
+
+* **Only the Hadoop-shaded old copy is affected.** CVE-2026-50193 (StackOverflow on `toString()` of a
+  deeply-nested `JsonNode`, fixed 2.14.0) and CVE-2026-54514 (eager DNS resolution / SSRF when
+  deserializing into `InetSocketAddress`, fixed 2.18.8 / 2.21.4) do not affect Solr's own
+  jackson-databind (2.18.0 in current 9.x, 2.22.0 in 9.11 — both patched). The `2.12.7.1` a scanner
+  flags is Hadoop's shaded copy, reachable only through the optional Hadoop modules, which process
+  administrator-supplied configuration rather than untrusted external JSON.
+* **Require Jackson features Solr does not use.** CVE-2026-54515 (case-insensitive deserialization
+  bypassing per-property `@JsonIgnoreProperties`), CVE-2026-59889 (`@JsonView` bypass for
+  `@JsonUnwrapped` container properties), CVE-2026-59888 (`@JsonIgnore` on a Record property bypassed
+  via a `PropertyNamingStrategy`), and GHSA-mhm7-754m-9p8w (`@JsonView` bypass for creator properties
+  with `@JsonTypeInfo(include = As.EXTERNAL_PROPERTY)`) can reach Solr's own jackson-databind, but
+  only when an application relies on those annotation-based mechanisms — case-insensitive property
+  mapping, `@JsonView`, `@JsonUnwrapped`, `@JsonIgnore` on records, or `@JsonTypeInfo` external-property
+  polymorphism — to restrict which fields untrusted input may set. Solr uses none of them: it maps
+  request JSON to fixed, known types and never applies `@JsonView`/`@JsonIgnore`-based deserialization
+  filtering or polymorphic typing to untrusted input, so these bypasses have nothing to bypass.

--- a/content/solr/vex/2026-07-31-cve-2026-54512.md
+++ b/content/solr/vex/2026-07-31-cve-2026-54512.md
@@ -1,0 +1,26 @@
+---
+cve:
+  - CVE-2026-54512
+  - CVE-2026-54513
+category:
+  - solr/vex
+versions: "4.7.0-10.0.0"
+jars:
+  - jackson-databind-2.12.7.1.jar
+analysis:
+  state: not_affected
+  justification: code_not_reachable
+title: "jackson-databind: PolymorphicTypeValidator allowlist bypasses (unsafe deserialization)"
+---
+CVE-2026-54512 and CVE-2026-54513 are bypasses of jackson-databind's `PolymorphicTypeValidator` — via
+generic type parameters (54512) and via an array-subtype allowlist gap in
+`allowIfSubType` (54513) — that can let unexpected classes be instantiated during polymorphic
+deserialization (affects 2.10.0–2.18.7 and 2.19.0–2.21.3).
+
+Solr is **not affected**. Both issues are only exploitable when an application enables **polymorphic
+deserialization** — default typing (`activateDefaultTyping`), `@JsonTypeInfo`, or a
+`BasicPolymorphicTypeValidator` allowlist — and then deserializes attacker-controlled JSON through it.
+Solr does none of this: it maps request JSON to fixed, known target types and never enables default
+typing or polymorphic deserialization of untrusted input, so the `PolymorphicTypeValidator` code path
+these CVEs target is never exercised. (The `2.12.7.1` copy a scanner flags is Hadoop's shaded
+jackson-databind; Solr's own is 2.18.0 in current 9.x and 2.22.0 in 9.11.)

--- a/content/solr/vex/2026-07-31-cve-2026-56740.md
+++ b/content/solr/vex/2026-07-31-cve-2026-56740.md
@@ -1,0 +1,26 @@
+---
+cve:
+  - CVE-2026-56740
+  - CVE-2026-56741
+category:
+  - solr/vex
+versions: "9.0.0-10.0.0"
+jars:
+  - jline-remote-telnet-3.9.0.jar
+analysis:
+  state: not_affected
+  justification: code_not_present
+title: "JLine: unauthenticated remote DoS in the Telnet server"
+---
+CVE-2026-56740 and CVE-2026-56741 are unauthenticated remote denial-of-service issues in **JLine's
+Telnet server** — unbounded NEW-ENVIRON variables (56740) and unbounded NAWS terminal-geometry values
+(56741) in the `jline-remote-telnet` Telnet daemon (affects < 3.30.14, and the 4.0.x / 4.1.x lines).
+
+Solr is **not affected**:
+
+* **The vulnerable component is not shipped or run.** Solr ships no `jline-remote-telnet` jar; the
+  `3.9.0` coordinate a scanner reports comes only from a dependency reference embedded in the bundled
+  `zookeeper-3.9.5` jar's metadata. Solr never starts a JLine Telnet server (`Telnetd`).
+* JLine is used, at most, for the local interactive `bin/solr` CLI terminal — a `LineReader` on the
+  operator's own console, not a network-listening Telnet daemon — so nothing accepts remote Telnet
+  connections that the vulnerable NAWS/NEW-ENVIRON parsing could act on.

--- a/content/solr/vex/2026-07-31-cve-2026-56745.md
+++ b/content/solr/vex/2026-07-31-cve-2026-56745.md
@@ -1,0 +1,32 @@
+---
+cve:
+  - CVE-2026-56745
+  - CVE-2026-55833
+  - CVE-2026-55831
+  - CVE-2026-56819
+  - CVE-2026-59901
+category:
+  - solr/vex
+versions: "9.2.0-10.0.0"
+jars:
+  - netty-codec-http-4.2.15.Final.jar
+  - netty-codec-http2-4.2.15.Final.jar
+  - netty-codec-compression-4.2.15.Final.jar
+analysis:
+  state: not_affected
+  justification: code_not_reachable
+title: "Netty codec: SPDY / HTTP2-decompression / Bzip2 denial-of-service issues"
+---
+These five Netty issues are resource-exhaustion / DoS bugs in server- and decoder-side code paths
+(all affect Netty < 4.1.136 and 4.2.0–4.2.15, fixed in 4.1.136 / 4.2.16):
+
+* CVE-2026-56745, CVE-2026-55833, CVE-2026-55831 — the **SPDY** codec (`SpdyHttpDecoder` and SPDY
+  header/settings handling) in `netty-codec-http`.
+* CVE-2026-56819 — server-side **HTTP/2 decompression** ByteBuf reference leak in `netty-codec-http2`.
+* CVE-2026-59901 — infinite loop in the **Bzip2** decoder in `netty-codec-compression`.
+
+Solr is **not affected**. Solr bundles Netty only via the optional OpenTelemetry (OTLP) exporter and
+the ZooKeeper client, where Netty acts strictly as a **client**. Solr's HTTP server is Jetty, not
+Netty: Solr never runs a Netty HTTP/HTTP2/SPDY server, never enables the SPDY codec, and never feeds
+attacker-controlled compressed (bzip2) streams through Netty. The vulnerable server/decoder code
+paths are therefore unreachable — the same reasoning as CVE-2026-33870 / CVE-2026-33871.

--- a/content/solr/vex/2026-07-31-cve-2026-59899.md
+++ b/content/solr/vex/2026-07-31-cve-2026-59899.md
@@ -1,0 +1,32 @@
+---
+cve:
+  - CVE-2026-59899
+  - CVE-2026-56746
+  - CVE-2026-59898
+  - CVE-2026-59921
+  - CVE-2026-59900
+category:
+  - solr/vex
+versions: "9.2.0-10.0.0"
+jars:
+  - netty-codec-http-4.2.15.Final.jar
+  - netty-codec-http2-4.2.15.Final.jar
+analysis:
+  state: not_affected
+  justification: code_not_reachable
+title: "Netty codec-http/http2: server-side HTTP handling issues (DoS, CORS/WebSocket, smuggling, CRLF)"
+---
+These five Netty issues live in server-side HTTP handling or the outbound request encoder (all affect
+Netty < 4.1.136 and 4.2.0–4.2.15, fixed in 4.1.136 / 4.2.16):
+
+* CVE-2026-59899 — unbounded per-connection queue growth in `HttpContentEncoder` via HTTP/1.1
+  pipelining (server response encoding).
+* CVE-2026-56746 — CORS short-circuit failure / security-control bypass (server CORS handler).
+* CVE-2026-59898 — WebSocket V07/V08 handshaker missing Connection/Upgrade validation (server).
+* CVE-2026-59921 — CRLF injection via multipart filename in the outbound `HttpPostRequestEncoder`.
+* CVE-2026-59900 — Host-header de-duplication gap in HTTP/2→HTTP/1.x translation (server/proxy).
+
+Solr is **not affected**. Solr bundles Netty only via the optional OpenTelemetry (OTLP) exporter and
+the ZooKeeper client, where Netty is used strictly as a **client**. Solr's HTTP server is Jetty:
+Solr never runs a Netty HTTP server, CORS handler, WebSocket server, or HTTP/2→1 proxy, and never
+uses Netty's multipart request encoder, so none of these code paths are reachable.

--- a/content/solr/vex/2026-07-31-cve-2026-59949.md
+++ b/content/solr/vex/2026-07-31-cve-2026-59949.md
@@ -1,0 +1,25 @@
+---
+cve: CVE-2026-59949
+category:
+  - solr/vex
+versions: "9.0.0-10.0.0"
+jars:
+  - lz4-java-1.10.1.jar
+analysis:
+  state: not_affected
+  justification: code_not_reachable
+title: "lz4-java: out-of-bounds read via invalid arguments to native XXHash"
+---
+CVE-2026-59949 (CVSS 6.5) is an out-of-bounds read in the `at.yawk.lz4:lz4-java` codec: the
+JNI-based XXHash implementations insufficiently validate their byte-array arguments, so a caller that
+passes an invalid array reference or an out-of-range `off`/`len` to the native XXHash methods can
+crash the JVM. It affects lz4-java ≤ 1.11.0 (fixed in 1.11.1). Exploitation requires an application
+to pass attacker-influenced array/offset/length values into those XXHash APIs.
+
+Solr is **not affected**. `lz4-java` is bundled only by the optional `cross-dc` module, where it is
+used by the embedded Apache Kafka client for LZ4 compression / checksums of cross-datacenter
+replication messages. Kafka calls the XXHash APIs with its own internally-managed, validated buffers
+and offsets — it does not forward attacker-controlled `off`/`len` values into the native methods —
+and the replication stream flows through an operator-controlled Kafka pipeline, not untrusted
+external input. The `cross-dc` module is not part of a default Solr installation, and no Solr request
+path reaches the vulnerable XXHash argument handling.

--- a/content/solr/vex/2026-07-31-cve-2026-6790.md
+++ b/content/solr/vex/2026-07-31-cve-2026-6790.md
@@ -1,0 +1,24 @@
+---
+cve: CVE-2026-6790
+category:
+  - solr/vex
+versions: "7.3.0-10.0.0"
+jars:
+  - jetty-server-10.0.26.jar
+analysis:
+  state: not_affected
+  justification: code_not_reachable
+title: "Eclipse Jetty: HTTP/2 :authority vs Host header confusion"
+---
+CVE-2026-6790 is an input-validation gap in Jetty's HTTP/2 (and HTTP/3) request processing: Jetty
+does not require the `:authority` pseudo-header to match the `Host` header, so a single request can
+carry two conflicting host interpretations. It affects the Jetty branches Solr ships (9.4.x, 10.0.x
+through 10.0.26, 12.0.x through 12.0.34). It has security impact only for applications that **make
+security-sensitive decisions based on the request host** — host-based access control, virtual-host
+isolation, multi-tenant routing, or host-derived redirect URLs.
+
+Solr is **not affected**. Solr does none of those things: it does not perform host-based access
+control or virtual-host/multi-tenant isolation, its authentication and authorization
+(`SolrDispatchFilter` / the `AuthenticationPlugin` framework) never key on the `Host`/`:authority`
+value, and it does not build security-sensitive redirects from the request host. With no
+host-dependent security decision, the host-confusion has no exploitable consequence in Solr.

--- a/content/solr/vex/2026-07-31-cve-2026-8384.md
+++ b/content/solr/vex/2026-07-31-cve-2026-8384.md
@@ -1,0 +1,34 @@
+---
+cve: CVE-2026-8384
+category:
+  - solr/vex
+versions: "7.3.0-10.0.0"
+jars:
+  - jetty-util-10.0.26.jar
+analysis:
+  state: not_affected
+  justification: code_not_reachable
+title: "Eclipse Jetty: non-canonical URL paths in URIUtil.canonicalPath (authorization bypass)"
+---
+CVE-2026-8384 is a path-canonicalization flaw in Jetty's `URIUtil.canonicalPath()`: a semicolon
+path-parameter marker before dot-dot segments (e.g. `/public;/../admin/secret`) is not normalized,
+so a path-prefix authorization check can be bypassed. It is exploitable by applications that use
+Jetty's `SecurityHandler.PathMapped`, or that make an authorization decision on a canonicalized path
+at a **different layer** than the one that ultimately dispatches the request (the classic
+canonicalization *desync*).
+
+Solr is **not affected**:
+
+* **No desync between authorization and dispatch.** `HttpSolrCall` computes the request path once
+  (`ServletUtils.getPathAfterContext()`), and uses that single value for *both* request routing
+  (`getPath()`) and authorization (`getAuthCtx()` builds its `AuthorizationContext` resource from the
+  same `getPath()`). `RuleBasedAuthorizationPlugin` therefore evaluates exactly the path that Solr
+  dispatches — there is no window in which authorization sees one path while a different path is
+  served, which is the precondition this CVE requires.
+* **Path parameters are already stripped.** Solr derives the path from `getServletPath()` +
+  `getPathInfo()`, which per the Servlet specification have path parameters (the `;…` segments this
+  bug abuses) removed by the container before Solr ever sees the path.
+* Solr uses neither Jetty's `SecurityHandler.PathMapped` nor `URIUtil.canonicalPath()` directly.
+
+So even on an affected Jetty, the mis-canonicalization cannot produce an authorization bypass in
+Solr, because Solr's authorization and dispatch are driven by the same, single path value.


### PR DESCRIPTION
Working towards completing coverage of VEX statements.    Since I am working with Snapshot images, some of the version ranges won't work, as we only do the "purl" on released versions of Solr.   However, this at least gets some statements in, and then when releases come out, I'll regenerate mappings and that will let OpenVex formatted file suppress these properly.

It's good to know that our -SNAPSHOTS are in a much better place for the dependencies.