### PR TITLE
SOLR-17900: Hadoop client CVEs, expand on one existing, add four new ones

### DIFF
--- a/content/solr/vex/2025-09-07-cve-2023-52428.md
+++ b/content/solr/vex/2025-09-07-cve-2023-52428.md
@@ -1,0 +1,25 @@
+---
+cve: CVE-2023-52428
+jira: SOLR-17900
+category:
+  - solr/vex
+versions: "9.0.0-9.10.1"
+jars:
+  - nimbus-jose-jwt-9.31.jar
+analysis:
+  state: not_affected
+  justification: code_not_reachable
+title: "Nimbus JOSE + JWT: denial of service parsing crafted JOSE objects"
+---
+CVE-2023-52428 (CVSS 8.7) is a denial-of-service issue in Nimbus JOSE + JWT: parsing a crafted JOSE
+object (for example a PBES2-encrypted JWE with a huge `p2c` iteration count, or a large deeply-nested
+structure) can consume excessive resources (fixed in 9.37.2). It is only reachable when an
+application parses attacker-supplied JOSE/JWT input with Nimbus.
+
+Solr is **not affected**. Solr's own JWT authentication (the optional `jwt-auth` module,
+`JWTAuthPlugin`) parses tokens with **jose4j**, not Nimbus (see CVE-2025-53864). The Nimbus copy a
+scanner flags (`nimbus-jose-jwt@9.31`) is shaded inside `hadoop-client-runtime` in the optional
+`hdfs` module and is only used by Hadoop's own internal auth machinery — Solr never routes an
+untrusted, externally-supplied JOSE object to it. The vulnerable parser is therefore not reached. The
+affected range spans the releases whose `hdfs` module bundles the affected shaded Nimbus (Solr
+9.0.0 – 9.10.1); Solr 10.x ships no `hadoop-client-runtime`.

--- a/content/solr/vex/2025-09-07-cve-2024-25638.md
+++ b/content/solr/vex/2025-09-07-cve-2024-25638.md
@@ -1,0 +1,25 @@
+---
+cve: CVE-2024-25638
+jira: SOLR-17900
+category:
+  - solr/vex
+versions: "9.0.0-9.10.1"
+jars:
+  - dnsjava-3.4.0.jar
+analysis:
+  state: not_affected
+  justification: code_not_reachable
+title: "dnsjava: DNSSEC validation bypass"
+---
+CVE-2024-25638 (CVSS 7.0) is a DNSSEC-validation bypass in dnsjava: a resolver relying on dnsjava to
+validate DNSSEC could be tricked into accepting spoofed records (affects dnsjava < 3.6.0). It matters
+only for an application that uses dnsjava as its resolver and relies on its DNSSEC validation for a
+security decision.
+
+Solr is **not affected**. dnsjava is not a Solr dependency in its own right — it is shaded inside
+`hadoop-client-runtime` (reported by scanners as `dnsjava@3.4.0`) in the optional `hdfs` module,
+where Hadoop may use it for name resolution. Solr uses the HDFS module only as a **client** that
+connects to operator-configured HDFS NameNode/DataNode hosts, not attacker-controlled names, and it
+does not rely on dnsjava's DNSSEC validation to make any security decision. The vulnerable resolver
+path is therefore not reached. The affected range spans the releases whose `hdfs` module bundles an
+affected shaded dnsjava (Solr 9.0.0 – 9.10.1); Solr 10.x ships no `hadoop-client-runtime`.

--- a/content/solr/vex/2025-09-07-cve-2024-26308.md
+++ b/content/solr/vex/2025-09-07-cve-2024-26308.md
@@ -1,0 +1,25 @@
+---
+cve: CVE-2024-26308
+jira: SOLR-17900
+category:
+  - solr/vex
+versions: "9.0.0-9.10.1"
+jars:
+  - commons-compress-1.24.0.jar
+analysis:
+  state: not_affected
+  justification: code_not_reachable
+title: "Apache Commons Compress: OutOfMemoryError unpacking a broken Pack200 file"
+---
+CVE-2024-26308 (CVSS 6.7) is a denial-of-service issue in Apache Commons Compress: unpacking a
+malformed **Pack200** (`.pack`/`.pack.gz`) stream can allocate excessive memory and throw
+`OutOfMemoryError` (affects 1.21 through 1.25.0, fixed in 1.26.0). It is reachable only when an
+application uses Commons Compress to unpack an attacker-supplied Pack200 archive.
+
+Solr is **not affected**. Solr never unpacks Pack200 archives — Pack200 (a legacy JAR-compression
+format) is not part of any Solr request path. The affected `commons-compress` a scanner flags
+(`commons-compress@1.24.0`) is the copy shaded into `hadoop-client-runtime` in the optional `hdfs`
+module; Solr's HDFS-client usage does not feed untrusted Pack200 input to it, and Solr's own use of
+Commons Compress elsewhere does not invoke the Pack200 unpacker. The vulnerable code path is therefore
+not reached. The affected range spans the releases whose `hdfs` module bundles an affected shaded
+commons-compress (Solr 9.0.0 – 9.10.1); Solr 10.x ships no `hadoop-client-runtime`.

--- a/content/solr/vex/2025-09-07-cve-2024-29131.md
+++ b/content/solr/vex/2025-09-07-cve-2024-29131.md
@@ -1,0 +1,28 @@
+---
+cve:
+  - CVE-2024-29131
+  - CVE-2024-29133
+jira: SOLR-17900
+category:
+  - solr/vex
+versions: "9.0.0-9.10.1"
+jars:
+  - commons-configuration2-2.8.0.jar
+analysis:
+  state: not_affected
+  justification: code_not_reachable
+title: "Apache Commons Configuration: StackOverflowError in list-delimiter handling"
+---
+CVE-2024-29131 and CVE-2024-29133 are denial-of-service issues (StackOverflowError) in Apache Commons
+Configuration's list-delimiter handling — `AbstractListDelimiterHandler.flattenIterator(...)` and
+`ListDelimiterHandler.flatten(Object, int)` respectively — when a configuration contains a cyclic
+reference (both affect 2.0 through 2.10.0, fixed in 2.10.1).
+
+Solr is **not affected**. Solr uses `commons-configuration2` only through its optional Hadoop
+integration — both the standalone copy in the `hadoop-auth` module and the copy shaded into
+`hadoop-client-runtime` (which a scanner reports as `commons-configuration2@2.8.0`) — to load
+**administrator-supplied** Hadoop configuration files, never untrusted external input. No Solr request
+path feeds attacker-controlled configuration to Commons Configuration, so the recursive list-delimiter
+parser cannot be driven by an adversary. This matches the existing assessment of the other Commons
+Configuration CVEs (CVE-2022-33980, CVE-2026-45205). The affected range spans the releases whose
+Hadoop modules carry an affected commons-configuration2 (Solr 9.0.0 – 9.10.1).

--- a/content/solr/vex/2026-07-31-cve-2024-47561.md
+++ b/content/solr/vex/2026-07-31-cve-2024-47561.md
@@ -2,6 +2,7 @@
 cve:
   - CVE-2024-47561
   - CVE-2023-39410
+jira: SOLR-17900
 category:
   - solr/vex
 versions: "9.0.0-9.10.1"
@@ -29,4 +30,6 @@ Solr is **not affected**:
   input.
 
 The affected range covers the 9.x line, where the optional Hadoop modules transitively carry Avro
-1.9.2; Solr's own code path never invokes it.
+1.9.2; Solr's own code path never invokes it. A scanner surfaces this as `avro@1.9.2` because Avro is
+shaded inside `hadoop-client-runtime-3.4.0.jar` in the `hdfs` module (this is the form reported by
+SOLR-17900); it is the same non-reachable Hadoop transitive either way.


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17900

VEX files for various hadoop client cves.  I had to check twice, as I thought hadoop was gone in a late 9x, but nope, still hanging on in 9.10.1.....
