### PR TITLE
SOLR-16309: document the jquery-ui CVE applicablity.

### DIFF
--- a/content/solr/vex/2025-09-07-cve-2021-41182.md
+++ b/content/solr/vex/2025-09-07-cve-2021-41182.md
@@ -1,0 +1,45 @@
+---
+# NOTE: This entry is unlike the other VEX files. They all cover Maven/Java jar
+# dependencies, whose `jars` become `pkg:maven/...` purls that scanners match. This
+# one documents a bundled front-end JavaScript library (jQuery UI, in the Admin UI),
+# so it is documentation-only: `jars` names a `.js` file, the generated OpenVEX
+# product is a bare id (not a matchable purl), and Docker Scout does not flag the
+# minified JS. Full jar/purl suppression would require extending the model to
+# npm/generic purls. See the body and SOLR-16309.
+cve:
+  - CVE-2021-41182
+  - CVE-2021-41183
+  - CVE-2021-41184
+jira: SOLR-16309
+category:
+  - solr/vex
+versions: "7.5.0-10.0.0"
+jars:
+  - jquery-ui-1.12.1.js
+analysis:
+  state: not_affected
+  justification: code_not_reachable
+title: "jQuery UI (Admin UI): XSS in datepicker and position widgets"
+---
+Three XSS issues in jQuery UI 1.12.1 (all fixed in 1.13.x):
+
+* **CVE-2021-41182** — XSS via the datepicker `altField` option.
+* **CVE-2021-41183** — XSS via the datepicker `*Text` options.
+* **CVE-2021-41184** — XSS via the `.position()` `of` option.
+
+Solr's Admin UI bundles a **custom subset** of jQuery UI (`server/solr-webapp/webapp/libs/jquery-ui.min.js`,
+v1.12.1) from Solr 7.5.0 through 10.0.0. Solr is **not affected**:
+
+* **The datepicker widget is not included.** Solr's build excludes datepicker entirely (it is absent
+  from the shipped `jquery-ui.min.js`), so CVE-2021-41182 and CVE-2021-41183 — both datepicker-only —
+  have no code present to exploit.
+* **The position utility is included, but not reachable with attacker input.** CVE-2021-41184
+  requires passing attacker-controlled markup to the `of` option of `.position()`. Solr's Admin UI
+  invokes positioning (for tooltips/dialogs) only with its own static, trusted selectors, never with
+  externally-supplied values. The Admin UI is also an operator-facing console, not an
+  unauthenticated public surface.
+
+> Note: this is a **front-end JavaScript** dependency, not a Maven artifact. This entry documents
+> Solr's assessment for the record; unlike the Java-jar entries it does not emit a matchable Maven
+> purl, and Docker Scout does not flag the bundled minified JS. It corresponds to SOLR-16309, whose
+> reporter likewise characterized it as a compliance finding rather than an exploitable risk.


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-16309

Jquery doesn't plug into openvex per se, but lets at least document this.