### PR TITLE
SOLR-15507: document that this was fixed "back in the day" as the refer to 8x

### DIFF
--- a/content/solr/vex/2025-09-07-cve-2020-13949.md
+++ b/content/solr/vex/2025-09-07-cve-2020-13949.md
@@ -1,0 +1,27 @@
+---
+cve: CVE-2020-13949
+jira: SOLR-15507
+category:
+  - solr/vex
+versions: "8.2.0-8.8.1"
+jars:
+  - libthrift-0.13.0.jar
+analysis:
+  state: not_affected
+  justification: code_not_reachable
+title: "Apache Thrift: server-side memory-exhaustion DoS via crafted short messages"
+---
+CVE-2020-13949 is a denial-of-service issue in Apache Thrift: a malicious RPC **client** can send
+specially-crafted short messages that cause a Thrift **server** to allocate a large amount of memory,
+potentially exhausting it (affects `libthrift` 0.9.3 – 0.13.0, fixed in 0.14.0). It is reachable only
+by an application that runs a Thrift server accepting messages from untrusted clients.
+
+Solr is **not affected**. `libthrift` is bundled only by the optional Jaeger distributed-tracing
+integration, where Solr uses Thrift purely as a **client** to export spans to an operator-configured
+Jaeger collector — it never runs a Thrift RPC server that accepts untrusted incoming messages. The
+vulnerable server-side allocation path is therefore never reached.
+
+Solr shipped an affected `libthrift` in the 8.x line — 0.12.0 (8.2.0) and 0.13.0 (8.5.0 – 8.8.1),
+both ≤ 0.13.0 — so the affected range is 8.2.0 – 8.8.1. Solr 9.0.0 upgraded to `libthrift` 0.14.1
+(and later 0.15.0), which are past the 0.14.0 fix, so no 9.x or 10.x release is affected. (The Solr
+8.x line is end of life.)


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-15507

Add a vex statement covering this one.