### PR TITLE
SOLR-17900 follow-up: narrow four Hadoop-shaded CVE ranges to 9.0.0-9.9.0

### DIFF
--- a/content/solr/vex/2025-09-07-cve-2023-52428.md
+++ b/content/solr/vex/2025-09-07-cve-2023-52428.md
@@ -3,7 +3,7 @@ cve: CVE-2023-52428
 jira: SOLR-17900
 category:
   - solr/vex
-versions: "9.0.0-9.10.1"
+versions: "9.0.0-9.9.0"
 jars:
   - nimbus-jose-jwt-9.31.jar
 analysis:
@@ -21,5 +21,7 @@ Solr is **not affected**. Solr's own JWT authentication (the optional `jwt-auth`
 scanner flags (`nimbus-jose-jwt@9.31`) is shaded inside `hadoop-client-runtime` in the optional
 `hdfs` module and is only used by Hadoop's own internal auth machinery — Solr never routes an
 untrusted, externally-supplied JOSE object to it. The vulnerable parser is therefore not reached. The
-affected range spans the releases whose `hdfs` module bundles the affected shaded Nimbus (Solr
-9.0.0 – 9.10.1); Solr 10.x ships no `hadoop-client-runtime`.
+affected range spans the releases whose `hdfs` module bundles an affected shaded Nimbus — Solr
+9.0.0 – 9.9.0 (`hadoop-client-runtime` 3.3.2 – 3.4.0, shading Nimbus ≤ 9.31). Solr 9.10.0 upgraded to
+Hadoop 3.4.1, whose `hadoop-client-runtime` shades the fixed Nimbus 9.37.2, and Solr 10.x ships no
+`hadoop-client-runtime`, so neither is affected.

--- a/content/solr/vex/2025-09-07-cve-2024-25638.md
+++ b/content/solr/vex/2025-09-07-cve-2024-25638.md
@@ -3,7 +3,7 @@ cve: CVE-2024-25638
 jira: SOLR-17900
 category:
   - solr/vex
-versions: "9.0.0-9.10.1"
+versions: "9.0.0-9.9.0"
 jars:
   - dnsjava-3.4.0.jar
 analysis:
@@ -22,4 +22,6 @@ where Hadoop may use it for name resolution. Solr uses the HDFS module only as a
 connects to operator-configured HDFS NameNode/DataNode hosts, not attacker-controlled names, and it
 does not rely on dnsjava's DNSSEC validation to make any security decision. The vulnerable resolver
 path is therefore not reached. The affected range spans the releases whose `hdfs` module bundles an
-affected shaded dnsjava (Solr 9.0.0 – 9.10.1); Solr 10.x ships no `hadoop-client-runtime`.
+affected shaded dnsjava — Solr 9.0.0 – 9.9.0 (`hadoop-client-runtime` 3.3.2 – 3.4.0, shading dnsjava
+≤ 3.4.0). Solr 9.10.0 upgraded to Hadoop 3.4.1, whose `hadoop-client-runtime` shades the fixed dnsjava
+3.6.1, and Solr 10.x ships no `hadoop-client-runtime`, so neither is affected.

--- a/content/solr/vex/2025-09-07-cve-2024-26308.md
+++ b/content/solr/vex/2025-09-07-cve-2024-26308.md
@@ -3,7 +3,7 @@ cve: CVE-2024-26308
 jira: SOLR-17900
 category:
   - solr/vex
-versions: "9.0.0-9.10.1"
+versions: "9.0.0-9.9.0"
 jars:
   - commons-compress-1.24.0.jar
 analysis:
@@ -22,4 +22,7 @@ format) is not part of any Solr request path. The affected `commons-compress` a 
 module; Solr's HDFS-client usage does not feed untrusted Pack200 input to it, and Solr's own use of
 Commons Compress elsewhere does not invoke the Pack200 unpacker. The vulnerable code path is therefore
 not reached. The affected range spans the releases whose `hdfs` module bundles an affected shaded
-commons-compress (Solr 9.0.0 – 9.10.1); Solr 10.x ships no `hadoop-client-runtime`.
+commons-compress — Solr 9.0.0 – 9.9.0 (`hadoop-client-runtime` 3.3.2 – 3.4.0, shading commons-compress
+≤ 1.24.0; the standalone copy in the `extraction` module was already ≥ 1.26.0 by 9.7.0). Solr 9.10.0
+upgraded to Hadoop 3.4.1, whose `hadoop-client-runtime` shades the fixed commons-compress 1.26.1, and
+Solr 10.x ships no `hadoop-client-runtime`, so neither is affected.

--- a/content/solr/vex/2025-09-07-cve-2024-29131.md
+++ b/content/solr/vex/2025-09-07-cve-2024-29131.md
@@ -5,7 +5,7 @@ cve:
 jira: SOLR-17900
 category:
   - solr/vex
-versions: "9.0.0-9.10.1"
+versions: "9.0.0-9.9.0"
 jars:
   - commons-configuration2-2.8.0.jar
 analysis:
@@ -25,4 +25,7 @@ integration — both the standalone copy in the `hadoop-auth` module and the cop
 path feeds attacker-controlled configuration to Commons Configuration, so the recursive list-delimiter
 parser cannot be driven by an adversary. This matches the existing assessment of the other Commons
 Configuration CVEs (CVE-2022-33980, CVE-2026-45205). The affected range spans the releases whose
-Hadoop modules carry an affected commons-configuration2 (Solr 9.0.0 – 9.10.1).
+Hadoop modules carry an affected commons-configuration2 — Solr 9.0.0 – 9.9.0 (`hadoop-client-runtime`
+3.3.2 – 3.4.0 shades commons-configuration2 ≤ 2.8.0; the standalone `hadoop-auth` copy was already
+≥ 2.10.1, at 2.11.0, by 9.7.0). Solr 9.10.0 upgraded to Hadoop 3.4.1, whose `hadoop-client-runtime`
+shades the fixed commons-configuration2 2.10.1, so 9.10.x onward is not affected.

--- a/content/solr/vex/2026-07-31-cve-2024-47561.md
+++ b/content/solr/vex/2026-07-31-cve-2024-47561.md
@@ -29,7 +29,11 @@ Solr is **not affected**:
   own internal machinery, driven by administrator-supplied configuration, not by untrusted request
   input.
 
-The affected range covers the 9.x line, where the optional Hadoop modules transitively carry Avro
-1.9.2; Solr's own code path never invokes it. A scanner surfaces this as `avro@1.9.2` because Avro is
-shaded inside `hadoop-client-runtime-3.4.0.jar` in the `hdfs` module (this is the form reported by
-SOLR-17900); it is the same non-reachable Hadoop transitive either way.
+The affected range covers Solr 9.0.0 – 9.10.1, where the optional Hadoop modules transitively carry a
+vulnerable Avro (1.7.7 in `hadoop-client-runtime` 3.3.2 – 3.3.6, then 1.9.2 in 3.4.0 – 3.4.1); Solr's
+own code path never invokes it. A scanner surfaces this as `avro@1.9.2` because Avro is shaded inside
+`hadoop-client-runtime` in the `hdfs` module (the form reported by SOLR-17900). Unlike the other
+Hadoop-shaded CVEs from SOLR-17900, Avro stayed vulnerable all the way through 9.10.1: Solr 9.11
+(branch_9x) is the first fixed release, having upgraded to Hadoop 3.4.3, whose `hadoop-client-runtime`
+shades Avro 1.11.4 (past both the 1.11.3 and 1.11.4 fixes). Solr 10.x ships no `hadoop-client-runtime`.
+Either way it is the same non-reachable Hadoop transitive.


### PR DESCRIPTION
Follow-up to #216. After digging back into the actual shaded dependency versions, the affected ranges on four of the Hadoop-client CVE statements were too broad.

The four CVEs are attributed to libraries shaded inside `hadoop-client-runtime` (in the `hdfs` module). Reading the embedded `pom.properties` from each `hadoop-client-runtime-*.jar` across the Solr 9.x line shows those shaded libs were bumped to fixed versions when Solr moved to **Hadoop 3.4.1 in Solr 9.10.0** — one release earlier than the `9.10.1` bound the statements claimed:

| CVE (shaded lib) | fix version | last vulnerable (Hadoop 3.4.0 = Solr 9.9.0) | fixed at |
|---|---|---|---|
| CVE-2023-52428 (nimbus-jose-jwt) | 9.37.2 | 9.31 | 9.10.0 (3.4.1 → 9.37.2) |
| CVE-2024-25638 (dnsjava) | 3.6.0 | 3.4.0 | 9.10.0 (3.4.1 → 3.6.1) |
| CVE-2024-26308 (commons-compress) | 1.26.0 | 1.24.0 | 9.10.0 (3.4.1 → 1.26.1) |
| CVE-2024-29131/29133 (commons-configuration2) | 2.10.1 | 2.8.0 | 9.10.0 (3.4.1 → 2.10.1) |

So the range on those four moves from `9.0.0-9.10.1` to **`9.0.0-9.9.0`**, with the body text updated to state the exact fix boundary.

The **avro** entry (CVE-2024-47561 / CVE-2023-39410) keeps its `9.0.0-9.10.1` range — avro stayed at 1.9.2 through 9.10.1 and is only fixed in 9.11 (branch_9x, Hadoop 3.4.3 → avro 1.11.4). Its body is updated to make that boundary explicit.

All statements remain `not_affected` / `code_not_reachable`; this only tightens the version metadata. Site builds and `vexctl merge` passes.