### PR TITLE
Correct CVE-2020-13949 (thrift) affected range to 8.2.0-8.11.0

### DIFF
--- a/content/solr/vex/2025-09-07-cve-2020-13949.md
+++ b/content/solr/vex/2025-09-07-cve-2020-13949.md
@@ -3,7 +3,7 @@ cve: CVE-2020-13949
 jira: SOLR-15507
 category:
   - solr/vex
-versions: "8.2.0-8.8.1"
+versions: "8.2.0-8.11.0"
 jars:
   - libthrift-0.13.0.jar
 analysis:
@@ -21,7 +21,10 @@ integration, where Solr uses Thrift purely as a **client** to export spans to an
 Jaeger collector — it never runs a Thrift RPC server that accepts untrusted incoming messages. The
 vulnerable server-side allocation path is therefore never reached.
 
-Solr shipped an affected `libthrift` in the 8.x line — 0.12.0 (8.2.0) and 0.13.0 (8.5.0 – 8.8.1),
-both ≤ 0.13.0 — so the affected range is 8.2.0 – 8.8.1. Solr 9.0.0 upgraded to `libthrift` 0.14.1
-(and later 0.15.0), which are past the 0.14.0 fix, so no 9.x or 10.x release is affected. (The Solr
-8.x line is end of life.)
+Solr shipped an affected `libthrift` in the 8.x line — 0.12.0 (8.2.0 – 8.4.1) and 0.13.0 (8.5.0 –
+8.11.0), both ≤ 0.13.0 — so the affected range is 8.2.0 – 8.11.0. Solr **8.11.1** upgraded the 8.x
+line to `libthrift` 0.14.1 (past the 0.14.0 fix), and Solr 9.0.0 likewise ships 0.14.1 (later 0.15.0),
+so no 8.11.1+, 9.x, or 10.x release is affected. (The Solr 8.x line is end of life.) Note that
+SOLR-15507 — which proposed the upgrade and observed that Solr 8.9.0 still bundled `libthrift` 0.13.0 —
+remains open with no fix version, but the upgrade was in fact delivered in 8.11.1 (verified against the
+`solr:8.11.0` and `solr:8.11.1` release images).


### PR DESCRIPTION
The `not_affected` statement for **CVE-2020-13949** (Apache Thrift server-side DoS, affects `libthrift` 0.9.3–0.13.0, fixed in 0.14.0) listed its affected range as `8.2.0-8.8.1`, but Solr's optional `jaegertracer-configurator` module shipped an affected `libthrift` well past 8.8.1.

Traced the actual bundled `libthrift` across the 8.x line:

| Solr 8.x | libthrift | status |
|---|---|---|
| 8.2.0 – 8.4.1 | 0.12.0 | vulnerable |
| 8.5.0 – 8.11.0 | 0.13.0 | vulnerable |
| **8.11.1** | **0.14.1** | **fixed** |
| 8.11.2+ | 0.14.1 | fixed |

So the range should be **`8.2.0-8.11.0`**, with the upgrade landing in **8.11.1**. This matches the observation in [SOLR-15507](https://issues.apache.org/jira/browse/SOLR-15507) that Solr 8.9.0 still bundled `libthrift` 0.13.0. The 8.8.1 → 8.11.0 boundary was verified against the `solr:8.11.0` (0.13.0) and `solr:8.11.1` (0.14.1) release images. SOLR-15507 itself remains Open with no fix version, but the upgrade was in fact delivered in 8.11.1.

Disposition is unchanged (`not_affected` / `code_not_reachable` — Solr uses Thrift only as a client). This only corrects the version metadata and the accompanying narrative.