### PR TITLE
Refine jackson-databind gadget CVE range to 4.7.0-8.6.3

### DIFF
--- a/content/solr/vex/2022-12-14-cve-2017-15095.md
+++ b/content/solr/vex/2022-12-14-cve-2017-15095.md
@@ -17,7 +17,7 @@ cve:
   - CVE-2019-16335
 category:
   - solr/vex
-versions: "4.7.0-8.x"
+versions: "4.7.0-8.6.3"
 jars:
   - jackson-databind-*.jar
 analysis:
@@ -25,5 +25,7 @@ analysis:
 title: "jackson-databind-*"
 ---
 These CVEs, and most of the known jackson-databind CVEs since 2017, are all related to problematic 'gadgets' that could be exploited during deserialization of untrusted data. The Jackson developers described 4 conditions that must be met in order for a problematic gadget to be exploited. See https://medium.com/@cowtowncoder/on-jackson-cves-dont-panic-here-is-what-you-need-to-know-54cd0d6e8062. Solr's use of jackson-databind does not meet 1 of the 4 conditions described which makes these CVEs unexploitable. The specific condition that Solr does not meet is the 3rd one: 'Enable polymorphic type handling' Solr does not include any polymorphic type handling, and Solr does not configure jackson-databind de/serialization to expect or include class names in serialized JSON. Two CVEs, 2019-14540 & 2019-16335, are related to HikariConfig and HikariDataSource classes, neither of which are used in Solr's code base.
+
+All 15 are pre-block-list "individual gadget" CVEs, fixed in jackson-databind ≤ 2.9.10.7 / ≤ 2.10.5.1 (the latest, CVE-2021-20190, in 2.10.5.1). Solr's **standalone** `jackson-databind` — the `jackson-databind-*.jar` this statement covers — was within that range from 4.7.0 through Solr **8.6.3**: 2.9.x up to 8.3.1, then 2.10.0 / 2.10.1 through 8.6.3 (all < 2.10.5.1). Solr 8.7.0 moved to jackson-databind 2.11.2 — past the fix — and 9.x / 10.x ship 2.13+ / 2.20, so from 8.7.0 onward the standalone copy is no longer flagged for these CVEs. (The separate old 2.x copy shaded inside `htrace-core4`, which spans the full 8.x line, is tracked in SOLR-17236 — see below.)
 
 SOLR-17236 tracks this same class of jackson-databind deserialization CVEs for the old 2.x copy shaded inside Hadoop's `htrace-core4` jar in the 8.x line; the same reasoning applies, and `htrace-core4` (with its bundled jackson-databind) was removed in Solr 9.x.


### PR DESCRIPTION
The `not_affected` statement for the 15 classic jackson-databind deserialization "gadget" CVEs (CVE-2017-15095 and 14 others) listed its range as `4.7.0-8.x`, but "all of 8.x" is too broad.

These are all the **pre-block-list "individual gadget" era** CVEs (2017–early 2021). Their fix versions cluster at **≤ 2.9.10.7 / ≤ 2.10.5.1** — the latest, CVE-2021-20190, is fixed in **2.10.5.1**. Mapping onto the jackson-databind Solr actually shipped:

| Solr | jackson-databind | in these CVEs' range? |
|---|---|---|
| 4.7.0 – 8.3.1 | 2.9.x (≤ 2.9.9.3) | yes |
| 8.4.0 – 8.6.3 | 2.10.0 / 2.10.1 | yes (< 2.10.5.1) |
| 8.7.0 – 8.9.x | 2.11.2 | no |
| 8.10.0 – 8.11.1 | 2.12.3 | no |
| 8.11.2 | 2.13.3 | no |
| 9.x / 10.x | 2.13+ / 2.20 | no |

So the standalone `jackson-databind` this statement covers is only within range through **8.6.3**; range corrected to **`4.7.0-8.6.3`**, with the body updated to explain the boundary.

The separate old 2.x jackson-databind shaded inside `htrace-core4` (which spans the full 8.x line and was removed in 9.x) is unaffected by this change — it remains tracked under SOLR-17236, as the entry already notes.

Disposition unchanged (`not_affected` — Solr enables no polymorphic/default typing). This only tightens the version metadata.