### PR TITLE
Cap CVE-2025-48734 (commons-beanutils) range at 9.10.1/10.0.0 — fixed in 9.11/10.1

### DIFF
--- a/content/solr/vex/2026-07-18-cve-2025-48734.md
+++ b/content/solr/vex/2026-07-18-cve-2025-48734.md
@@ -2,7 +2,7 @@
 cve: CVE-2025-48734
 category:
   - solr/vex
-versions: "3.6.0-10.0.0"
+versions: "3.6.0-9.10.1, 10.0.0"
 jars:
   - commons-beanutils-1.9.4.jar
 analysis:
@@ -15,4 +15,10 @@ CVE-2025-48734 allows an attacker to access the JVM ClassLoader (and potentially
 CVE-2025-48734 affects all Commons BeanUtils 1.x releases before 1.11.0. Solr has bundled
 commons-beanutils since Solr 3.6.0, and every release that includes it, through Solr 10.0.0, ships an
 affected 1.x version (1.7.0, then 1.8.3, 1.9.3 and 1.9.4 — all below 1.11.0). The affected range is
-therefore 3.6.0 – 10.0.0.
+therefore 3.6.0 – 9.10.1 plus 10.0.0.
+
+The fix has landed on all active development branches: Solr 9.11 (`branch_9x`), 10.1 (`branch_10x`),
+and `main` upgrade the bundled copy to commons-beanutils 1.11.0, and Hadoop 3.4.3 (shipped in 9.11)
+additionally dropped the shaded commons-beanutils it previously carried inside `hadoop-client-runtime`.
+So 9.11 and 10.1 are not affected, and the range is capped at 9.10.1 / 10.0.0 rather than an open
+`3.6.0 – 10.0.0` that would otherwise sweep in the fixed 9.11 release.


### PR DESCRIPTION
The `not_affected` statement for **CVE-2025-48734** (commons-beanutils `declaredClass` class-loader access) used an open range `3.6.0-10.0.0`. The upgrade to commons-beanutils 1.11.0 (SOLR-17825 / SOLR-17918) has since landed on every active development branch, so the affected range should be capped.

Verified across images, shaded uber-jar contents, and per-module lockfiles:

| Solr | shaded in `hadoop-client-runtime` | standalone (`cross-dc-manager`) | verdict |
|---|---|---|---|
| 9.0.0–9.7.0 | 1.9.4 | — | affected |
| 9.8.0–9.10.1 | 1.9.4 | 1.9.4 | affected |
| 10.0.0 (no hadoop) | — | 1.9.4 | affected |
| **9.11 / branch_9x** | gone (Hadoop 3.4.3 dropped it) | **1.11.0** | **fixed** |
| **10.1 / branch_10x, main** | — | **1.11.0** | **fixed** |

Two things make 9.11 clean: the `cross-dc-manager` copy was upgraded to **1.11.0**, and Hadoop **3.4.3** (shipped in 9.11) removed the shaded commons-beanutils that 3.4.1 carried inside `hadoop-client-runtime` (3.4.1 shaded 161 beanutils classes; 3.4.3 has none). 10.1/main have no Hadoop and ship the 1.11.0 standalone copy.

Change: `versions: "3.6.0-10.0.0"` → **`"3.6.0-9.10.1, 10.0.0"`**, plus a body note documenting the fix. The comma form matters because a plain `3.6.0-10.0.0` would wrongly sweep in the fixed 9.11 (it sorts below 10.0.0) once released. Disposition unchanged (`not_affected` / `code_not_reachable`). Site builds, statement emits the correct `commons-beanutils` purls, `vexctl merge` passes.